### PR TITLE
Adds --delete flag to rsync in deploy workflow to fix stale file issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Sync code to server
         run: |
-          rsync -avz --no-g --no-perms \
+          rsync -avz --delete --no-g --no-perms \
             --exclude node_modules \
             --exclude .git \
             --exclude .env \


### PR DESCRIPTION
## Description

Fixes deployment failure caused by stale files remaining on the server after being removed from the repository. The `worldSlice.ts` file was removed during the state management migration but persisted on the deployment server, causing TypeScript build errors during Docker build.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

Fixes deployment failure in GitHub Actions run #20879446068

## Changes Made

- Added `--delete` flag to rsync command in deploy workflow
- This ensures files removed from the repository are also removed from the deployment server
- Excluded directories (.env, data, node_modules, etc.) are protected from deletion by existing `--exclude` flags

## Testing

### Test Environment

- OS: N/A (CI workflow change)
- Browser (if applicable): N/A
- Node version: N/A
- Python version (if applicable): N/A

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Merge this PR to main
2. Deployment workflow will run automatically
3. Verify the stale `worldSlice.ts` file is removed and build succeeds

## Screenshots/Videos

N/A

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: Adding `--delete` to rsync may slightly increase sync time on first run as it removes stale files, but this is negligible.

## Breaking Changes

**Breaking changes:**
- None

**Migration guide:**
- None required

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The root cause was that rsync without `--delete` doesn't remove files from the destination that no longer exist in the source. When `worldSlice.ts` was removed in PR #50 (state management migration), the file remained on the server and caused TypeScript errors during the Docker build.

## Reviewer Guidance

This is a simple one-line infrastructure fix. The key consideration is that the `--exclude` flags protect important server-side files (.env, data directory, etc.) from being deleted.