### PR TITLE
fix: Multi-persona ontology type creation and shared type tracking

### DIFF
--- a/annotation-tool/src/components/ontology/EntityTypeEditor.tsx
+++ b/annotation-tool/src/components/ontology/EntityTypeEditor.tsx
@@ -65,6 +65,7 @@ export default function EntityTypeEditor({ open, onClose, entity, personaId }: E
       setGloss(entity.gloss)
       setExamples(entity.examples || [])
       setMode('manual')
+      // When editing, always use the current persona only
       setTargetPersonaIds([personaId || ''])
       setWikidataId(entity.wikidataId || '')
       setWikidataUrl(entity.wikidataUrl || '')
@@ -76,7 +77,11 @@ export default function EntityTypeEditor({ open, onClose, entity, personaId }: E
       setMode('manual')
       setSourcePersonaId('')
       setSourceEntityId('')
-      setTargetPersonaIds([personaId || ''])
+      // Don't reset targetPersonaIds when creating - preserve user's persona selections
+      // Only initialize if empty (first open)
+      if (targetPersonaIds.length === 0 || (targetPersonaIds.length === 1 && targetPersonaIds[0] === '')) {
+        setTargetPersonaIds([personaId || ''])
+      }
       setWikidataId('')
       setWikidataUrl('')
       setImportedAt('')
@@ -119,9 +124,13 @@ export default function EntityTypeEditor({ open, onClose, entity, personaId }: E
       }
     } else {
       // Creating new entity types for selected personas
+      // Generate a shared ID if creating for multiple personas
+      const sharedTypeId = targetPersonaIds.length > 1 ? generateId() : undefined
+
       await Promise.all(targetPersonaIds.map(async (targetId) => {
         const entityData: EntityType = {
           id: generateId(),
+          sharedTypeId,
           name,
           gloss,
           examples,

--- a/annotation-tool/src/components/ontology/EventTypeEditor.tsx
+++ b/annotation-tool/src/components/ontology/EventTypeEditor.tsx
@@ -113,25 +113,42 @@ export default function EventTypeEditor({ open, onClose, event, personaId }: Eve
     if (!personaId) return
 
     const now = new Date().toISOString()
-    const eventData: EventType = {
-      id: event?.id || generateId(),
-      name,
-      gloss,
-      roles,
-      examples,
-      wikidataId: wikidataId || undefined,
-      wikidataUrl: wikidataUrl || undefined,
-      importedFrom: mode === 'wikidata' ? 'wikidata' : mode === 'copy' ? 'persona' : undefined,
-      importedAt: wikidataId ? (importedAt || now) : undefined,
-      createdAt: event?.createdAt || now,
-      updatedAt: now,
-    }
 
     if (event) {
+      // Editing existing event type
+      const eventData: EventType = {
+        ...event,
+        name,
+        gloss,
+        roles,
+        examples,
+        wikidataId: wikidataId || undefined,
+        wikidataUrl: wikidataUrl || undefined,
+        importedFrom: mode === 'wikidata' ? 'wikidata' : mode === 'copy' ? 'persona' : undefined,
+        importedAt: wikidataId ? (importedAt || now) : undefined,
+        updatedAt: now,
+      }
       await updateEvent({ personaId, event: eventData })
     } else {
+      // Creating new event types for selected personas
+      // Generate a shared ID if creating for multiple personas
+      const sharedTypeId = targetPersonaIds.length > 1 ? generateId() : undefined
+
       await Promise.all(targetPersonaIds.map(async (targetId) => {
-        const newEventData = { ...eventData, id: generateId() }
+        const newEventData: EventType = {
+          id: generateId(),
+          sharedTypeId,
+          name,
+          gloss,
+          roles,
+          examples,
+          wikidataId: wikidataId || undefined,
+          wikidataUrl: wikidataUrl || undefined,
+          importedFrom: mode === 'wikidata' ? 'wikidata' : mode === 'copy' ? 'persona' : undefined,
+          importedAt: wikidataId ? now : undefined,
+          createdAt: now,
+          updatedAt: now,
+        }
         await addEvent({ personaId: targetId, event: newEventData })
       }))
     }

--- a/annotation-tool/src/components/ontology/RelationTypeEditor.tsx
+++ b/annotation-tool/src/components/ontology/RelationTypeEditor.tsx
@@ -15,6 +15,7 @@ import {
   Tabs,
   Tab,
   FormControl,
+  FormGroup,
   InputLabel,
   Select,
   MenuItem,
@@ -33,6 +34,7 @@ import {
 } from '@mui/icons-material'
 import { generateId } from '@utils/uuid'
 import {
+  usePersonas,
   usePersonaOntology,
   useAddRelationTypeToPersona,
   useUpdateRelationTypeInPersona,
@@ -56,6 +58,7 @@ export default function RelationTypeEditor({
   personaId,
 }: RelationTypeEditorProps) {
   // TanStack Query hooks
+  const { data: personas = [] } = usePersonas()
   const { data: ontology } = usePersonaOntology(personaId)
   const { mutateAsync: addRelationTypeMutation } = useAddRelationTypeToPersona()
   const { mutateAsync: updateRelationTypeMutation } = useUpdateRelationTypeInPersona()
@@ -63,6 +66,7 @@ export default function RelationTypeEditor({
   const { mutate: deleteRelationMutation } = useDeleteRelationFromPersona()
 
   const [tabValue, setTabValue] = useState(0)
+  const [targetPersonaIds, setTargetPersonaIds] = useState<string[]>([personaId || ''])
   const [name, setName] = useState('')
   const [gloss, setGloss] = useState<GlossItem[]>([])
   const [sourceTypes, setSourceTypes] = useState<('entity' | 'role' | 'event' | 'time' | 'claim')[]>([])
@@ -88,6 +92,8 @@ export default function RelationTypeEditor({
       setTransitive(relationType.transitive || false)
       setExamples(relationType.examples || [])
       setTabValue(0) // Start on definition tab when editing
+      // When editing, always use the current persona only
+      setTargetPersonaIds([personaId || ''])
     } else {
       setName('')
       setGloss([])
@@ -97,11 +103,16 @@ export default function RelationTypeEditor({
       setTransitive(false)
       setExamples([])
       setTabValue(0)
+      // Don't reset targetPersonaIds when creating - preserve user's persona selections
+      // Only initialize if empty (first open)
+      if (targetPersonaIds.length === 0 || (targetPersonaIds.length === 1 && targetPersonaIds[0] === '')) {
+        setTargetPersonaIds([personaId || ''])
+      }
     }
     setExampleInput('')
     setSourceId('')
     setTargetId('')
-  }, [relationType])
+  }, [relationType, personaId])
 
   const handleSave = async () => {
     if (!personaId) return
@@ -110,23 +121,43 @@ export default function RelationTypeEditor({
     if (!name.trim() || !gloss.some(g => g.content.trim())) return
     if (sourceTypes.length === 0 || targetTypes.length === 0) return
 
-    const relationTypeData: RelationType = {
-      id: relationType?.id || generateId(),
-      name,
-      gloss,
-      sourceTypes,
-      targetTypes,
-      symmetric,
-      transitive,
-      examples,
-      createdAt: relationType?.createdAt || new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    }
+    const now = new Date().toISOString()
 
     if (relationType) {
+      // Editing existing relation type
+      const relationTypeData: RelationType = {
+        ...relationType,
+        name,
+        gloss,
+        sourceTypes,
+        targetTypes,
+        symmetric,
+        transitive,
+        examples,
+        updatedAt: now,
+      }
       await updateRelationTypeMutation({ personaId, relationType: relationTypeData })
     } else {
-      await addRelationTypeMutation({ personaId, relationType: relationTypeData })
+      // Creating new relation types for selected personas
+      // Generate a shared ID if creating for multiple personas
+      const sharedTypeId = targetPersonaIds.length > 1 ? generateId() : undefined
+
+      await Promise.all(targetPersonaIds.map(async (targetId) => {
+        const relationTypeData: RelationType = {
+          id: generateId(),
+          sharedTypeId,
+          name,
+          gloss,
+          sourceTypes,
+          targetTypes,
+          symmetric,
+          transitive,
+          examples,
+          createdAt: now,
+          updatedAt: now,
+        }
+        await addRelationTypeMutation({ personaId: targetId, relationType: relationTypeData })
+      }))
     }
 
     onClose()
@@ -523,6 +554,36 @@ export default function RelationTypeEditor({
                 ))}
               </List>
             )}
+          </Box>
+        )}
+
+        {/* Persona selection for new relation types */}
+        {!relationType && personas.length > 1 && (
+          <Box sx={{ mt: 2 }}>
+            <Divider sx={{ mb: 2 }} />
+            <Typography variant="subtitle2" gutterBottom>
+              Add to Personas
+            </Typography>
+            <FormGroup>
+              {personas.map(persona => (
+                <FormControlLabel
+                  key={persona.id}
+                  control={
+                    <Checkbox
+                      checked={targetPersonaIds.includes(persona.id)}
+                      onChange={() => {
+                        setTargetPersonaIds(
+                          targetPersonaIds.includes(persona.id)
+                            ? targetPersonaIds.filter(id => id !== persona.id)
+                            : [...targetPersonaIds, persona.id]
+                        )
+                      }}
+                    />
+                  }
+                  label={persona.name}
+                />
+              ))}
+            </FormGroup>
           </Box>
         )}
       </DialogContent>

--- a/annotation-tool/src/components/ontology/RoleEditor.tsx
+++ b/annotation-tool/src/components/ontology/RoleEditor.tsx
@@ -107,25 +107,42 @@ export default function RoleEditor({ open, onClose, role, personaId }: RoleEdito
     if (!personaId) return
 
     const now = new Date().toISOString()
-    const roleData: RoleType = {
-      id: role?.id || generateId(),
-      name,
-      gloss,
-      allowedFillerTypes,
-      examples,
-      wikidataId: wikidataId || undefined,
-      wikidataUrl: wikidataUrl || undefined,
-      importedFrom: mode === 'wikidata' ? 'wikidata' : mode === 'copy' ? 'persona' : undefined,
-      importedAt: wikidataId ? (importedAt || now) : undefined,
-      createdAt: role?.createdAt || now,
-      updatedAt: now,
-    }
 
     if (role) {
+      // Editing existing role type
+      const roleData: RoleType = {
+        ...role,
+        name,
+        gloss,
+        allowedFillerTypes,
+        examples,
+        wikidataId: wikidataId || undefined,
+        wikidataUrl: wikidataUrl || undefined,
+        importedFrom: mode === 'wikidata' ? 'wikidata' : mode === 'copy' ? 'persona' : undefined,
+        importedAt: wikidataId ? (importedAt || now) : undefined,
+        updatedAt: now,
+      }
       await updateRole({ personaId, role: roleData })
     } else {
+      // Creating new role types for selected personas
+      // Generate a shared ID if creating for multiple personas
+      const sharedTypeId = targetPersonaIds.length > 1 ? generateId() : undefined
+
       await Promise.all(targetPersonaIds.map(async (targetId) => {
-        const newRoleData = { ...roleData, id: generateId() }
+        const newRoleData: RoleType = {
+          id: generateId(),
+          sharedTypeId,
+          name,
+          gloss,
+          allowedFillerTypes,
+          examples,
+          wikidataId: wikidataId || undefined,
+          wikidataUrl: wikidataUrl || undefined,
+          importedFrom: mode === 'wikidata' ? 'wikidata' : mode === 'copy' ? 'persona' : undefined,
+          importedAt: wikidataId ? now : undefined,
+          createdAt: now,
+          updatedAt: now,
+        }
         await addRole({ personaId: targetId, role: newRoleData })
       }))
     }

--- a/annotation-tool/src/components/world/EntityEditor.tsx
+++ b/annotation-tool/src/components/world/EntityEditor.tsx
@@ -88,17 +88,46 @@ export default function EntityEditor({ open, onClose, entity }: EntityEditorProp
 
   const handleAddTypeAssignment = () => {
     if (selectedPersonaId && selectedEntityTypeId) {
-      const newAssignment: EntityTypeAssignment = {
-        personaId: selectedPersonaId,
-        entityTypeId: selectedEntityTypeId,
-        confidence: assignmentConfidence,
-        justification: assignmentJustification || undefined,
+      // Get the selected type to check for sharedTypeId or wikidataId
+      const selectedOntology = personaOntologies.find(o => o.personaId === selectedPersonaId)
+      const selectedType = selectedOntology?.entities.find(e => e.id === selectedEntityTypeId)
+
+      const assignments: EntityTypeAssignment[] = []
+
+      // Check for sharedTypeId or wikidataId to find linked types across personas
+      const sharedId = selectedType?.sharedTypeId || selectedType?.wikidataId
+
+      if (sharedId) {
+        // Find all types with matching sharedTypeId or wikidataId across all personas
+        for (const ontology of personaOntologies) {
+          const matchingType = ontology.entities.find(e =>
+            e.sharedTypeId === sharedId ||
+            (selectedType?.wikidataId && e.wikidataId === selectedType.wikidataId)
+          )
+          if (matchingType) {
+            assignments.push({
+              personaId: ontology.personaId,
+              entityTypeId: matchingType.id,
+              confidence: assignmentConfidence,
+              justification: assignmentJustification || undefined,
+            })
+          }
+        }
+      } else {
+        // No sharedTypeId, just add single assignment
+        assignments.push({
+          personaId: selectedPersonaId,
+          entityTypeId: selectedEntityTypeId,
+          confidence: assignmentConfidence,
+          justification: assignmentJustification || undefined,
+        })
       }
-      
-      // Remove any existing assignment for this persona
-      const filtered = typeAssignments.filter(a => a.personaId !== selectedPersonaId)
-      setTypeAssignments([...filtered, newAssignment])
-      
+
+      // Remove existing assignments for all personas being updated
+      const personaIdsToReplace = new Set(assignments.map(a => a.personaId))
+      const filtered = typeAssignments.filter(a => !personaIdsToReplace.has(a.personaId))
+      setTypeAssignments([...filtered, ...assignments])
+
       // Reset form
       setSelectedEntityTypeId('')
       setAssignmentConfidence(1.0)

--- a/annotation-tool/src/hooks/annotation/useAnnotationDrawing.ts
+++ b/annotation-tool/src/hooks/annotation/useAnnotationDrawing.ts
@@ -4,9 +4,9 @@
  * Extracted from AnnotationOverlay to provide reusable drawing logic for video annotations.
  */
 
-import { useState, useCallback, RefObject } from 'react'
+import { useState, useCallback, RefObject, useMemo } from 'react'
 import { useAnnotationUiStore } from '@store/zustand'
-import { useAddAnnotation } from '@store/queries'
+import { useAddAnnotation, usePersonas, useAllPersonaOntologies } from '@store/queries'
 import type { Annotation } from '@models/types'
 
 /**
@@ -118,6 +118,11 @@ export function useAnnotationDrawing({
 
   // TanStack Query mutation for adding annotations
   const { mutate: addAnnotation } = useAddAnnotation()
+
+  // Get persona ontologies for shared type lookup
+  const { data: personas = [] } = usePersonas()
+  const personaIds = useMemo(() => personas.map((p) => p.id), [personas])
+  const { data: personaOntologies = [] } = useAllPersonaOntologies(personaIds)
 
   /**
    * Determines if drawing is allowed based on current annotation mode and requirements.
@@ -254,17 +259,82 @@ export function useAnnotationDrawing({
         updatedAt: new Date().toISOString(),
       }
 
-      let annotation: NewAnnotationInput
-
       if (annotationMode === 'type') {
-        annotation = {
-          ...baseAnnotation,
-          annotationType: 'type',
-          personaId: selectedPersonaId ?? undefined,
-          typeCategory: drawingMode as 'entity' | 'role' | 'event',
-          typeId: selectedTypeId ?? 'temp-type',
+        // Look up the selected type to check for sharedTypeId
+        const selectedOntology = personaOntologies.find(o => o.personaId === selectedPersonaId)
+        const typeCategory = drawingMode as 'entity' | 'role' | 'event'
+
+        // Get the appropriate type array based on category
+        let selectedType: { id: string; sharedTypeId?: string; wikidataId?: string } | undefined
+        if (typeCategory === 'entity') {
+          selectedType = selectedOntology?.entities.find(e => e.id === selectedTypeId)
+        } else if (typeCategory === 'role') {
+          selectedType = selectedOntology?.roles.find(r => r.id === selectedTypeId)
+        } else if (typeCategory === 'event') {
+          selectedType = selectedOntology?.events.find(e => e.id === selectedTypeId)
+        }
+
+        // Check for sharedTypeId or wikidataId to find linked types
+        const sharedId = selectedType?.sharedTypeId || selectedType?.wikidataId
+        let isFirstAnnotation = true
+
+        if (sharedId && personaOntologies.length > 1) {
+          // Create annotations for all personas with matching shared type
+          for (const ontology of personaOntologies) {
+            let matchingType: { id: string; sharedTypeId?: string; wikidataId?: string } | undefined
+            if (typeCategory === 'entity') {
+              matchingType = ontology.entities.find(e =>
+                e.sharedTypeId === sharedId ||
+                (selectedType?.wikidataId && e.wikidataId === selectedType.wikidataId)
+              )
+            } else if (typeCategory === 'role') {
+              matchingType = ontology.roles.find(r =>
+                r.sharedTypeId === sharedId ||
+                (selectedType?.wikidataId && r.wikidataId === selectedType.wikidataId)
+              )
+            } else if (typeCategory === 'event') {
+              matchingType = ontology.events.find(e =>
+                e.sharedTypeId === sharedId ||
+                (selectedType?.wikidataId && e.wikidataId === selectedType.wikidataId)
+              )
+            }
+
+            if (matchingType) {
+              const annotation: NewAnnotationInput = {
+                ...baseAnnotation,
+                annotationType: 'type',
+                personaId: ontology.personaId,
+                typeCategory,
+                typeId: matchingType.id,
+              }
+
+              addAnnotation(annotation, {
+                onSuccess: isFirstAnnotation ? (savedAnnotation) => {
+                  // Auto-select the first created annotation to show timeline
+                  setSelectedAnnotation(savedAnnotation)
+                } : undefined,
+              })
+              isFirstAnnotation = false
+            }
+          }
+        } else {
+          // No sharedTypeId, create single annotation
+          const annotation: NewAnnotationInput = {
+            ...baseAnnotation,
+            annotationType: 'type',
+            personaId: selectedPersonaId ?? undefined,
+            typeCategory,
+            typeId: selectedTypeId ?? 'temp-type',
+          }
+
+          addAnnotation(annotation, {
+            onSuccess: (savedAnnotation) => {
+              setSelectedAnnotation(savedAnnotation)
+            },
+          })
         }
       } else {
+        // Object annotation mode - single annotation
         const objectAnnotation: NewAnnotationInput = {
           ...baseAnnotation,
           annotationType: 'object',
@@ -279,15 +349,13 @@ export function useAnnotationDrawing({
           objectAnnotation.linkedCollectionId = linkTargetId ?? undefined
           objectAnnotation.linkedCollectionType = linkTargetType.replace('-collection', '') as 'entity' | 'event' | 'time'
         }
-        annotation = objectAnnotation
-      }
 
-      addAnnotation(annotation, {
-        onSuccess: (savedAnnotation) => {
-          // Auto-select the newly created annotation to show timeline
-          setSelectedAnnotation(savedAnnotation)
-        },
-      })
+        addAnnotation(objectAnnotation, {
+          onSuccess: (savedAnnotation) => {
+            setSelectedAnnotation(savedAnnotation)
+          },
+        })
+      }
     }
 
     setIsDrawing(false)
@@ -308,6 +376,7 @@ export function useAnnotationDrawing({
     addAnnotation,
     setSelectedAnnotation,
     resetDrawingState,
+    personaOntologies,
   ])
 
   return {

--- a/annotation-tool/src/models/ontology.ts
+++ b/annotation-tool/src/models/ontology.ts
@@ -9,6 +9,8 @@ import type { GlossItem, TypeConstraint } from './gloss'
 export interface EntityType {
   /** Unique identifier for the entity type */
   id: string
+  /** Shared identifier linking equivalent types across personas */
+  sharedTypeId?: string
   /** Display name for the entity type */
   name: string
   /** Rich text definition/description of the entity type */
@@ -41,6 +43,8 @@ export interface EntityType {
 export interface RoleType {
   /** Unique identifier for the role type */
   id: string
+  /** Shared identifier linking equivalent types across personas */
+  sharedTypeId?: string
   /** Display name for the role type */
   name: string
   /** Rich text definition/description of the role type */
@@ -94,6 +98,8 @@ export interface EventRole {
 export interface EventType {
   /** Unique identifier for the event type */
   id: string
+  /** Shared identifier linking equivalent types across personas */
+  sharedTypeId?: string
   /** Display name for the event type */
   name: string
   /** Rich text definition/description of the event type */
@@ -128,6 +134,8 @@ export interface EventType {
 export interface RelationType {
   /** Unique identifier for the relation type */
   id: string
+  /** Shared identifier linking equivalent types across personas */
+  sharedTypeId?: string
   /** Display name for the relation type */
   name: string
   /** Rich text definition/description of the relation */

--- a/annotation-tool/test/e2e/regression/ontology/multi-persona-types.spec.ts
+++ b/annotation-tool/test/e2e/regression/ontology/multi-persona-types.spec.ts
@@ -1,0 +1,431 @@
+import { test, expect } from '../../fixtures/test-context.js'
+
+/**
+ * Regression tests for multi-persona type creation and shared type functionality.
+ * Tests that types can be created for multiple personas simultaneously with shared type IDs.
+ */
+test.describe('Multi-Persona Type Creation', () => {
+  test('creates entity type for multiple personas with same sharedTypeId', async ({
+    ontologyWorkspace,
+    db,
+    page,
+    testUser,
+    workerSessionToken
+  }) => {
+    // Create 2 personas
+    const persona1 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Analyst Alpha',
+      role: 'Intelligence Analyst'
+    }, workerSessionToken)
+
+    const persona2 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Analyst Beta',
+      role: 'Strategic Analyst'
+    }, workerSessionToken)
+
+    try {
+      // Navigate to ontology workspace for persona 1
+      await ontologyWorkspace.navigateTo(persona1.id)
+      await ontologyWorkspace.selectTab('entities')
+      await ontologyWorkspace.addTypeFab.click()
+      await page.waitForTimeout(300)
+
+      // Wait for dialog
+      const dialog = page.locator('[role="dialog"]')
+      await dialog.waitFor({ state: 'visible', timeout: 5000 })
+
+      // Fill the name field
+      const nameInput = dialog.getByRole('textbox', { name: /^name/i }).first()
+      await nameInput.fill('SharedVehicle')
+
+      // Fill the definition
+      const defInput = dialog.locator('textarea').first()
+      await defInput.fill('A type shared between personas')
+
+      // Look for persona checkboxes and select the second persona
+      // The checkboxes should be visible when creating a new type
+      const persona2Checkbox = dialog.getByRole('checkbox', { name: /Analyst Beta/i }).or(
+        dialog.locator('label').filter({ hasText: /Analyst Beta/i }).locator('input[type="checkbox"]')
+      )
+
+      // If multi-persona selection UI exists, check persona2
+      const checkboxVisible = await persona2Checkbox.isVisible({ timeout: 2000 }).catch(() => false)
+      if (checkboxVisible) {
+        await persona2Checkbox.check()
+      }
+
+      // Save the type
+      const saveButton = dialog.getByRole('button', { name: /save|create/i })
+      await saveButton.click()
+      await page.waitForTimeout(1000)
+
+      // Verify type exists in persona 1
+      await ontologyWorkspace.expectTypeExists('SharedVehicle')
+
+      // Get the entity type from persona 1 to check sharedTypeId
+      const type1 = await db.getEntityTypeByName(persona1.id, 'SharedVehicle')
+      expect(type1).not.toBeNull()
+
+      // Navigate to persona 2 to check if type was created there
+      await ontologyWorkspace.navigateTo(persona2.id)
+      await ontologyWorkspace.selectTab('entities')
+
+      // Check if type exists in persona 2 (depends on whether multi-persona UI was available)
+      if (checkboxVisible) {
+        await ontologyWorkspace.expectTypeExists('SharedVehicle')
+
+        // Get the entity type from persona 2
+        const type2 = await db.getEntityTypeByName(persona2.id, 'SharedVehicle')
+        expect(type2).not.toBeNull()
+
+        // Verify both types have the same sharedTypeId
+        expect(type1!.sharedTypeId).toBeDefined()
+        expect(type2!.sharedTypeId).toBeDefined()
+        expect(type1!.sharedTypeId).toBe(type2!.sharedTypeId)
+
+        // Verify they have different type IDs (unique per persona)
+        expect(type1!.id).not.toBe(type2!.id)
+      }
+    } finally {
+      // Cleanup
+      await db.deletePersona(persona1.id)
+      await db.deletePersona(persona2.id)
+    }
+  })
+
+  test('persona selection is preserved when interacting with form fields', async ({
+    ontologyWorkspace,
+    db,
+    page,
+    testUser,
+    workerSessionToken
+  }) => {
+    // Create 2 personas
+    const persona1 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Test Persona 1',
+      role: 'Analyst'
+    }, workerSessionToken)
+
+    const persona2 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Test Persona 2',
+      role: 'Researcher'
+    }, workerSessionToken)
+
+    try {
+      // Navigate to ontology workspace for persona 1
+      await ontologyWorkspace.navigateTo(persona1.id)
+      await ontologyWorkspace.selectTab('entities')
+      await ontologyWorkspace.addTypeFab.click()
+      await page.waitForTimeout(300)
+
+      const dialog = page.locator('[role="dialog"]')
+      await dialog.waitFor({ state: 'visible', timeout: 5000 })
+
+      // Look for persona checkboxes
+      const persona2Checkbox = dialog.getByRole('checkbox', { name: /Test Persona 2/i }).or(
+        dialog.locator('label').filter({ hasText: /Test Persona 2/i }).locator('input[type="checkbox"]')
+      )
+
+      const checkboxVisible = await persona2Checkbox.isVisible({ timeout: 2000 }).catch(() => false)
+
+      if (checkboxVisible) {
+        // Select persona 2
+        await persona2Checkbox.check()
+
+        // Verify it's checked
+        const isChecked1 = await persona2Checkbox.isChecked()
+        expect(isChecked1).toBe(true)
+
+        // Now interact with the name field (this used to reset persona selection)
+        const nameInput = dialog.getByRole('textbox', { name: /^name/i }).first()
+        await nameInput.click()
+        await nameInput.fill('TestType')
+
+        // Wait a moment for any potential state updates
+        await page.waitForTimeout(300)
+
+        // Verify persona 2 is still checked (bug regression test)
+        const isChecked2 = await persona2Checkbox.isChecked()
+        expect(isChecked2).toBe(true)
+
+        // Now interact with the definition field
+        const defInput = dialog.locator('textarea').first()
+        await defInput.click()
+        await defInput.fill('A test type definition')
+
+        await page.waitForTimeout(300)
+
+        // Verify persona 2 is still checked after interacting with another field
+        const isChecked3 = await persona2Checkbox.isChecked()
+        expect(isChecked3).toBe(true)
+      }
+
+      // Cancel the dialog
+      const cancelButton = dialog.getByRole('button', { name: /cancel/i })
+      await cancelButton.click()
+    } finally {
+      await db.deletePersona(persona1.id)
+      await db.deletePersona(persona2.id)
+    }
+  })
+
+  test('single persona type creation does not include sharedTypeId', async ({
+    ontologyWorkspace,
+    db,
+    testPersona
+  }) => {
+    // Navigate and create a type for single persona
+    await ontologyWorkspace.navigateTo(testPersona.id)
+    await ontologyWorkspace.createEntityType('SinglePersonaType', 'A type for single persona')
+
+    await ontologyWorkspace.selectTab('entities')
+    await ontologyWorkspace.expectTypeExists('SinglePersonaType')
+
+    // Verify the type does NOT have a sharedTypeId (single persona = no sharing)
+    const entityType = await db.getEntityTypeByName(testPersona.id, 'SinglePersonaType')
+    expect(entityType).not.toBeNull()
+    expect(entityType!.sharedTypeId).toBeUndefined()
+  })
+
+  test('types are isolated between personas by default', async ({
+    ontologyWorkspace,
+    db,
+    page,
+    testUser,
+    workerSessionToken
+  }) => {
+    // Create 2 personas
+    const persona1 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Isolated Persona A',
+      role: 'Analyst'
+    }, workerSessionToken)
+
+    const persona2 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Isolated Persona B',
+      role: 'Analyst'
+    }, workerSessionToken)
+
+    try {
+      // Create type for persona 1 only (without selecting persona 2)
+      await ontologyWorkspace.navigateTo(persona1.id)
+      await ontologyWorkspace.createEntityType('IsolatedType', 'Only in persona A')
+
+      await ontologyWorkspace.selectTab('entities')
+      await ontologyWorkspace.expectTypeExists('IsolatedType')
+
+      // Navigate to persona 2
+      await ontologyWorkspace.navigateTo(persona2.id)
+      await page.waitForLoadState('networkidle')
+      await ontologyWorkspace.selectTab('entities')
+
+      // Verify type does NOT exist in persona 2
+      await ontologyWorkspace.expectTypeNotExists('IsolatedType')
+    } finally {
+      await db.deletePersona(persona1.id)
+      await db.deletePersona(persona2.id)
+    }
+  })
+
+  test('multi-persona event type creation', async ({
+    ontologyWorkspace,
+    db,
+    page,
+    testUser,
+    workerSessionToken
+  }) => {
+    const persona1 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Event Persona A',
+      role: 'Event Analyst'
+    }, workerSessionToken)
+
+    const persona2 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Event Persona B',
+      role: 'Event Analyst'
+    }, workerSessionToken)
+
+    try {
+      await ontologyWorkspace.navigateTo(persona1.id)
+      await ontologyWorkspace.selectTab('events')
+      await ontologyWorkspace.addTypeFab.click()
+      await page.waitForTimeout(300)
+
+      const dialog = page.locator('[role="dialog"]')
+      await dialog.waitFor({ state: 'visible', timeout: 5000 })
+
+      // Fill form
+      const nameInput = dialog.getByRole('textbox', { name: /^name/i }).first()
+      await nameInput.fill('SharedMeeting')
+
+      const defInput = dialog.locator('textarea').first()
+      await defInput.fill('A meeting event type')
+
+      // Try to select second persona
+      const persona2Checkbox = dialog.getByRole('checkbox', { name: /Event Persona B/i }).or(
+        dialog.locator('label').filter({ hasText: /Event Persona B/i }).locator('input[type="checkbox"]')
+      )
+
+      const checkboxVisible = await persona2Checkbox.isVisible({ timeout: 2000 }).catch(() => false)
+      if (checkboxVisible) {
+        await persona2Checkbox.check()
+      }
+
+      // Save
+      const saveButton = dialog.getByRole('button', { name: /save|create/i })
+      await saveButton.click()
+      await page.waitForTimeout(1000)
+
+      // Verify in persona 1
+      await ontologyWorkspace.expectTypeExists('SharedMeeting')
+
+      // Navigate to persona 2 and verify if multi-select was available
+      if (checkboxVisible) {
+        await ontologyWorkspace.navigateTo(persona2.id)
+        await ontologyWorkspace.selectTab('events')
+        await ontologyWorkspace.expectTypeExists('SharedMeeting')
+      }
+    } finally {
+      await db.deletePersona(persona1.id)
+      await db.deletePersona(persona2.id)
+    }
+  })
+
+  test('multi-persona role type creation', async ({
+    ontologyWorkspace,
+    db,
+    page,
+    testUser,
+    workerSessionToken
+  }) => {
+    const persona1 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Role Persona A',
+      role: 'Role Analyst'
+    }, workerSessionToken)
+
+    const persona2 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Role Persona B',
+      role: 'Role Analyst'
+    }, workerSessionToken)
+
+    try {
+      await ontologyWorkspace.navigateTo(persona1.id)
+      await ontologyWorkspace.selectTab('roles')
+      await ontologyWorkspace.addTypeFab.click()
+      await page.waitForTimeout(300)
+
+      const dialog = page.locator('[role="dialog"]')
+      await dialog.waitFor({ state: 'visible', timeout: 5000 })
+
+      // Fill form
+      const nameInput = dialog.getByRole('textbox', { name: /^name/i }).first()
+      await nameInput.fill('SharedAgent')
+
+      const defInput = dialog.locator('textarea').first()
+      await defInput.fill('An agent role type')
+
+      // Try to select second persona
+      const persona2Checkbox = dialog.getByRole('checkbox', { name: /Role Persona B/i }).or(
+        dialog.locator('label').filter({ hasText: /Role Persona B/i }).locator('input[type="checkbox"]')
+      )
+
+      const checkboxVisible = await persona2Checkbox.isVisible({ timeout: 2000 }).catch(() => false)
+      if (checkboxVisible) {
+        await persona2Checkbox.check()
+      }
+
+      // Save
+      const saveButton = dialog.getByRole('button', { name: /save|create/i })
+      await saveButton.click()
+      await page.waitForTimeout(1000)
+
+      // Verify in persona 1
+      await ontologyWorkspace.expectTypeExists('SharedAgent')
+
+      // Navigate to persona 2 and verify if multi-select was available
+      if (checkboxVisible) {
+        await ontologyWorkspace.navigateTo(persona2.id)
+        await ontologyWorkspace.selectTab('roles')
+        await ontologyWorkspace.expectTypeExists('SharedAgent')
+      }
+    } finally {
+      await db.deletePersona(persona1.id)
+      await db.deletePersona(persona2.id)
+    }
+  })
+
+  test('multi-persona relation type creation', async ({
+    ontologyWorkspace,
+    db,
+    page,
+    testUser,
+    workerSessionToken
+  }) => {
+    const persona1 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Relation Persona A',
+      role: 'Relation Analyst'
+    }, workerSessionToken)
+
+    const persona2 = await db.createPersona({
+      userId: testUser.id,
+      name: 'Relation Persona B',
+      role: 'Relation Analyst'
+    }, workerSessionToken)
+
+    try {
+      await ontologyWorkspace.navigateTo(persona1.id)
+      await ontologyWorkspace.selectTab('relations')
+      await ontologyWorkspace.addTypeFab.click()
+      await page.waitForTimeout(300)
+
+      const dialog = page.locator('[role="dialog"]')
+      await dialog.waitFor({ state: 'visible', timeout: 5000 })
+
+      // Fill relation type form (uses different field labels)
+      const nameInput = dialog.getByLabel('Relation Type Name', { exact: false }).or(
+        dialog.getByRole('textbox', { name: /relation.*type.*name/i })
+      )
+      await nameInput.fill('SharedConnection')
+
+      const defInput = dialog.locator('textarea').first()
+      await defInput.fill('A connection relation type')
+
+      // Try to select second persona
+      const persona2Checkbox = dialog.getByRole('checkbox', { name: /Relation Persona B/i }).or(
+        dialog.locator('label').filter({ hasText: /Relation Persona B/i }).locator('input[type="checkbox"]')
+      )
+
+      const checkboxVisible = await persona2Checkbox.isVisible({ timeout: 2000 }).catch(() => false)
+      if (checkboxVisible) {
+        await persona2Checkbox.check()
+      }
+
+      // Save
+      const saveButton = dialog.getByRole('button', { name: /save|create/i })
+      await saveButton.click()
+      await page.waitForTimeout(1000)
+
+      // Verify in persona 1
+      await ontologyWorkspace.expectTypeExists('SharedConnection')
+
+      // Navigate to persona 2 and verify if multi-select was available
+      if (checkboxVisible) {
+        await ontologyWorkspace.navigateTo(persona2.id)
+        await ontologyWorkspace.selectTab('relations')
+        await ontologyWorkspace.expectTypeExists('SharedConnection')
+      }
+    } finally {
+      await db.deletePersona(persona1.id)
+      await db.deletePersona(persona2.id)
+    }
+  })
+})

--- a/annotation-tool/test/e2e/utils/database-helpers.ts
+++ b/annotation-tool/test/e2e/utils/database-helpers.ts
@@ -36,6 +36,7 @@ export interface EntityType {
   id: string
   name: string
   definition: string
+  sharedTypeId?: string
 }
 
 export interface EventType {
@@ -475,8 +476,39 @@ export class DatabaseHelper {
       name: entityType.name,
       definition: Array.isArray(entityType.gloss)
         ? entityType.gloss.find((g: any) => g.type === 'text')?.content || ''
-        : entityType.gloss
+        : entityType.gloss,
+      sharedTypeId: entityType.sharedTypeId
     } : null
+  }
+
+  /**
+   * Get all entity types for a persona.
+   * @param personaId - ID of persona
+   */
+  async getEntityTypes(personaId: string): Promise<EntityType[]> {
+    const getResponse = await fetch(`${this.apiURL}/api/personas/${personaId}/ontology`)
+    if (!getResponse.ok) {
+      return []
+    }
+    const ontology = await getResponse.json()
+    return (ontology.entities || []).map((entityType: any) => ({
+      id: entityType.id,
+      name: entityType.name,
+      definition: Array.isArray(entityType.gloss)
+        ? entityType.gloss.find((g: any) => g.type === 'text')?.content || ''
+        : entityType.gloss,
+      sharedTypeId: entityType.sharedTypeId
+    }))
+  }
+
+  /**
+   * Get entity type by name for a persona.
+   * @param personaId - ID of persona
+   * @param name - Name of entity type
+   */
+  async getEntityTypeByName(personaId: string, name: string): Promise<EntityType | null> {
+    const entityTypes = await this.getEntityTypes(personaId)
+    return entityTypes.find(e => e.name === name) || null
   }
 
   /**

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -23,6 +23,7 @@ export interface TypeConstraint {
 
 export interface EntityType {
   id: string
+  sharedTypeId?: string
   name: string
   gloss: GlossItem[]
   constraints?: TypeConstraint[]
@@ -33,6 +34,7 @@ export interface EntityType {
 
 export interface RoleType {
   id: string
+  sharedTypeId?: string
   name: string
   gloss: GlossItem[]
   allowedFillerTypes: ('entity' | 'event')[]
@@ -52,6 +54,7 @@ export interface EventRole {
 
 export interface EventType {
   id: string
+  sharedTypeId?: string
   name: string
   gloss: GlossItem[]
   roles: EventRole[]
@@ -217,6 +220,7 @@ export interface TimeSpan {
 
 export interface RelationType {
   id: string
+  sharedTypeId?: string
   name: string
   gloss: GlossItem[]
   sourceTypes: ('entity' | 'role' | 'event' | 'time')[]

--- a/server/src/services/export-schemas.ts
+++ b/server/src/services/export-schemas.ts
@@ -104,6 +104,7 @@ export const BoundingBoxSequenceSchema = z.object({
  */
 export const EntityTypeSchema = z.object({
   id: z.string(),
+  sharedTypeId: z.string().optional(),
   name: z.string().min(1),
   gloss: z.array(GlossItemSchema),
   constraints: z.array(TypeConstraintSchema).optional(),
@@ -128,6 +129,7 @@ export const EventRoleSchema = z.object({
  */
 export const EventTypeSchema = z.object({
   id: z.string(),
+  sharedTypeId: z.string().optional(),
   name: z.string().min(1),
   gloss: z.array(GlossItemSchema),
   roles: z.array(EventRoleSchema),
@@ -142,6 +144,7 @@ export const EventTypeSchema = z.object({
  */
 export const RoleTypeSchema = z.object({
   id: z.string(),
+  sharedTypeId: z.string().optional(),
   name: z.string().min(1),
   gloss: z.array(GlossItemSchema),
   allowedFillerTypes: z.array(z.enum(['entity', 'event'])),
@@ -156,6 +159,7 @@ export const RoleTypeSchema = z.object({
  */
 export const RelationTypeSchema = z.object({
   id: z.string(),
+  sharedTypeId: z.string().optional(),
   name: z.string().min(1),
   gloss: z.array(GlossItemSchema),
   sourceTypes: z.array(z.enum(['entity', 'role', 'event', 'time'])),


### PR DESCRIPTION
## Description

Fixes two bugs related to multi-persona ontology type creation and adds shared type tracking functionality. When creating ontology types, users can now select multiple personas and the types will be created for all selected personas with a shared identifier linking them.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Fixes #
Relates to #

## Changes Made

- Fixed EntityTypeEditor useEffect to not reset targetPersonaIds when creating new types (was causing persona selections to be lost)
- Applied same fix pattern to EventTypeEditor and RoleEditor
- Added multi-persona UI support to RelationTypeEditor (which doesn't use BaseTypeEditor)
- Added `sharedTypeId` field to EntityType, RoleType, EventType, RelationType interfaces
- When creating types for multiple personas, generates shared sharedTypeId to link equivalent types
- EntityEditor: When assigning a shared type to a world entity, auto-creates assignments for all personas with matching sharedTypeId
- useAnnotationDrawing: When creating TypeAnnotation with shared type, auto-creates annotations for all personas with matching sharedTypeId
- Also supports wikidataId as implicit sharedTypeId for Wikidata-imported types
- Updated server-side types and export schemas to include sharedTypeId

## Testing

### Test Environment

- OS: macOS
- Browser (if applicable): Chrome
- Node version: 20.x
- Python version (if applicable): N/A

### Test Cases

- [ ] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [ ] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Create two personas in the ontology workspace
2. Open one persona's ontology and click "Add Type" for entity types
3. Check the checkbox for the second persona in the dialog
4. Fill in name and definition, then save
5. Verify the type appears in both personas' ontologies
6. Create a world entity and assign the shared type from one persona
7. Verify type assignments are auto-created for both personas

## Screenshots/Videos

N/A

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details:

## Breaking Changes

**Breaking changes:**
- None

**Migration guide:**
- N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The eslint warning about useEffect missing `targetPersonaIds` dependency in EntityTypeEditor is intentional - including it would cause the effect to run when personas are checked/unchecked, which would reset them (the original bug).

## Reviewer Guidance

Please pay attention to:
1. The useEffect dependency arrays in the type editors - the omission of targetPersonaIds is deliberate
2. The auto-assignment logic in EntityEditor and useAnnotationDrawing - verify it correctly finds matching types by sharedTypeId or wikidataId