### PR TITLE
Fixes bounding box coordinate offset, selection persistence, and label display issues

### DIFF
--- a/annotation-tool/src/components/annotation/AnnotationOverlay.tsx
+++ b/annotation-tool/src/components/annotation/AnnotationOverlay.tsx
@@ -9,7 +9,7 @@
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useAnnotationUiStore } from '@store/zustand'
-import { useAnnotations } from '@store/queries'
+import { useAnnotations, usePersonas, useAllPersonaOntologies } from '@store/queries'
 import { useEntities, useEvents, useEntityCollections, useEventCollections } from '@store/queries/useWorld'
 import DrawingCanvas from './DrawingCanvas'
 import type { DetectionResponse } from '@api/client'
@@ -24,6 +24,8 @@ type EnrichedAnnotation = Annotation & {
   linkedObject?: Entity | Event | EntityCollection | EventCollection
   /** Type of the linked object */
   linkedType?: 'entity' | 'event' | 'location' | 'entity-collection' | 'event-collection'
+  /** Resolved type name from ontology (for type annotations) */
+  typeName?: string
 }
 
 /**
@@ -97,6 +99,11 @@ export default function AnnotationOverlay({
   const entityCollections = useEntityCollections()
   const eventCollections = useEventCollections()
 
+  // TanStack Query for persona ontologies (to look up type names)
+  const { data: personas = [] } = usePersonas()
+  const personaIds = useMemo(() => personas.map(p => p.id), [personas])
+  const { data: personaOntologies = [] } = useAllPersonaOntologies(personaIds)
+
   // Create lookup maps for O(1) entity/event/collection lookups
   // This is much faster than O(n) .find() calls per annotation
   const entityMap = useMemo(
@@ -115,6 +122,24 @@ export default function AnnotationOverlay({
     () => new Map(eventCollections.map(c => [c.id, c])),
     [eventCollections]
   )
+
+  // Create lookup map for type names from ontologies
+  // Maps typeId -> typeName for O(1) lookups
+  const typeNameMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const ontology of personaOntologies) {
+      for (const entity of ontology.entities) {
+        map.set(entity.id, entity.name)
+      }
+      for (const role of ontology.roles) {
+        map.set(role.id, role.name)
+      }
+      for (const event of ontology.events) {
+        map.set(event.id, event.name)
+      }
+    }
+    return map
+  }, [personaOntologies])
 
   /**
    * Compute annotations with linked object information for display.
@@ -137,6 +162,14 @@ export default function AnnotationOverlay({
     }).map((ann): EnrichedAnnotation => {
       // Start with base annotation
       const enriched: EnrichedAnnotation = { ...ann }
+
+      // Enrich type annotations with type name from ontology
+      if (ann.annotationType === 'type') {
+        const typeName = typeNameMap.get(ann.typeId)
+        if (typeName) {
+          enriched.typeName = typeName
+        }
+      }
 
       // Get linked object info (only for object annotations)
       // Using O(1) Map lookups instead of O(n) .find() calls
@@ -173,7 +206,7 @@ export default function AnnotationOverlay({
 
       return enriched
     })
-  }, [annotations, currentTime, entityMap, eventMap, entityCollectionMap, eventCollectionMap, selectedAnnotation])
+  }, [annotations, currentTime, entityMap, eventMap, entityCollectionMap, eventCollectionMap, typeNameMap, selectedAnnotation])
 
   return (
     <DrawingCanvas

--- a/annotation-tool/src/components/annotation/AnnotationWorkspace.tsx
+++ b/annotation-tool/src/components/annotation/AnnotationWorkspace.tsx
@@ -240,6 +240,15 @@ export default function AnnotationWorkspace() {
     return 'Object Annotation'
   }, [worldEntities, worldEvents, worldTimes])
 
+  // Helper function to get object kind for consistent color coding
+  const getObjectKind = useCallback((annotation: ObjectAnnotation): string => {
+    if (annotation.linkedEntityId) return 'entity'
+    if (annotation.linkedEventId) return 'event'
+    if (annotation.linkedLocationId) return 'location'
+    if (annotation.linkedCollectionId) return 'collection'
+    return 'object'
+  }, [])
+
   // Keyframe control callbacks
   const handleAddKeyframe = useCallback(() => {
     if (!selectedAnnotation) return
@@ -932,11 +941,27 @@ export default function AnnotationWorkspace() {
                               </Typography>
                             </>
                           )}
-                          {annotation.annotationType === 'object' && (
-                            <Typography variant="body2" noWrap>
-                              {getObjectName(annotation as ObjectAnnotation)}
-                            </Typography>
-                          )}
+                          {annotation.annotationType === 'object' && (() => {
+                            const objAnn = annotation as ObjectAnnotation
+                            return (
+                              <>
+                                <Chip
+                                  label={getObjectKind(objAnn)}
+                                  size="small"
+                                  color={
+                                    objAnn.linkedEntityId ? 'success' :
+                                    objAnn.linkedEventId ? 'warning' :
+                                    objAnn.linkedLocationId ? 'secondary' :
+                                    'error'  // collections
+                                  }
+                                  sx={{ height: 20, fontSize: '0.75rem' }}
+                                />
+                                <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+                                  {getObjectName(objAnn)}
+                                </Typography>
+                              </>
+                            )
+                          })()}
                         </Box>
                       }
                       secondary={

--- a/annotation-tool/src/components/annotation/DrawingCanvas.tsx
+++ b/annotation-tool/src/components/annotation/DrawingCanvas.tsx
@@ -27,8 +27,8 @@ interface DrawingCanvasProps {
   videoHeight: number
   /** Video frame rate (defaults to 30) */
   videoFps?: number
-  /** Annotations to display */
-  annotations: Annotation[]
+  /** Annotations to display (may be enriched with typeName and linkedObject) */
+  annotations: (Annotation & { typeName?: string; linkedObject?: { name: string } })[]
   /** Currently selected annotation */
   selectedAnnotation: Annotation | null
   /** Optional AI detection results to display as read-only overlays */
@@ -168,6 +168,8 @@ export default function DrawingCanvas({
                 isActive={selectedAnnotation?.id === ann.id}
                 onSelect={() => onAnnotationSelect(ann)}
                 mode={mode}
+                typeName={ann.typeName}
+                linkedObject={ann.linkedObject}
               />
             </g>
           )

--- a/annotation-tool/src/components/annotation/InteractiveBoundingBox.tsx
+++ b/annotation-tool/src/components/annotation/InteractiveBoundingBox.tsx
@@ -38,6 +38,10 @@ interface InteractiveBoundingBoxProps {
   mode: 'keyframe' | 'interpolated' | 'ghost'
   /** Optional callback fired when bounding box is updated */
   onUpdate?: (box: Partial<BoundingBox>) => void
+  /** Resolved type name from ontology (for type annotations) */
+  typeName?: string
+  /** Resolved linked object with name (for object annotations) */
+  linkedObject?: { name: string }
 }
 
 type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | null
@@ -76,6 +80,8 @@ export default function InteractiveBoundingBox({
   onSelect,
   mode,
   onUpdate,
+  typeName,
+  linkedObject,
 }: InteractiveBoundingBoxProps) {
   // TanStack Query mutations for annotation operations
   const addKeyframe = useAddKeyframe()
@@ -156,24 +162,26 @@ export default function InteractiveBoundingBox({
   const strokeColor = getStrokeColor()
 
   // Get visual style based on mode
+  // Type annotations use thinner stroke (2px), object annotations use thicker stroke (4px)
   const getVisualStyle = () => {
+    const baseStroke = annotation.annotationType === 'type' ? 2 : 4
     switch (mode) {
       case 'keyframe':
         return {
           opacity: isActive || hovering ? 1.0 : 0.8,
-          strokeWidth: 4,
+          strokeWidth: baseStroke,
           strokeDasharray: undefined,
         }
       case 'interpolated':
         return {
           opacity: 0.6,
-          strokeWidth: 3,
+          strokeWidth: baseStroke * 0.75,
           strokeDasharray: undefined,
         }
       case 'ghost':
         return {
           opacity: 0.5,
-          strokeWidth: 3,
+          strokeWidth: baseStroke * 0.75,
           strokeDasharray: '5,5',
         }
     }
@@ -230,7 +238,9 @@ export default function InteractiveBoundingBox({
     }
   }, [annotation.id])
 
-  // Get relative coordinates within the SVG
+  // Get relative coordinates within the SVG using native matrix transformation
+  // This correctly handles viewBox and preserveAspectRatio (letterboxing/pillarboxing)
+  // Falls back to simple ratio calculation in test environments (jsdom)
   const getRelativeCoordinates = (e: React.MouseEvent): { x: number; y: number } => {
     // Get the SVG element - look for parent SVG
     let svg: SVGSVGElement | null = svgRef.current
@@ -242,9 +252,22 @@ export default function InteractiveBoundingBox({
       svg = element as SVGSVGElement
       svgRef.current = svg
     }
-    
+
     if (!svg) return { x: 0, y: 0 }
-    
+
+    // Use SVG's native coordinate transformation matrix when available
+    if (typeof svg.createSVGPoint === 'function' && typeof svg.getScreenCTM === 'function') {
+      const ctm = svg.getScreenCTM()
+      if (ctm) {
+        const pt = svg.createSVGPoint()
+        pt.x = e.clientX
+        pt.y = e.clientY
+        const svgPoint = pt.matrixTransform(ctm.inverse())
+        return { x: svgPoint.x, y: svgPoint.y }
+      }
+    }
+
+    // Fallback for test environments (jsdom) where SVG methods aren't available
     const rect = svg.getBoundingClientRect()
     return {
       x: ((e.clientX - rect.left) / rect.width) * videoWidth,
@@ -259,9 +282,29 @@ export default function InteractiveBoundingBox({
     const svg = svgRef.current
     if (!svg) return
 
-    const rect = svg.getBoundingClientRect()
-    const currentX = ((e.clientX - rect.left) / rect.width) * videoWidth
-    const currentY = ((e.clientY - rect.top) / rect.height) * videoHeight
+    // Calculate current coordinates using SVG matrix transformation when available
+    // Falls back to simple ratio calculation in test environments (jsdom)
+    let currentX: number
+    let currentY: number
+
+    if (typeof svg.createSVGPoint === 'function' && typeof svg.getScreenCTM === 'function') {
+      const ctm = svg.getScreenCTM()
+      if (ctm) {
+        const pt = svg.createSVGPoint()
+        pt.x = e.clientX
+        pt.y = e.clientY
+        const svgPoint = pt.matrixTransform(ctm.inverse())
+        currentX = svgPoint.x
+        currentY = svgPoint.y
+      } else {
+        return
+      }
+    } else {
+      // Fallback for test environments
+      const rect = svg.getBoundingClientRect()
+      currentX = ((e.clientX - rect.left) / rect.width) * videoWidth
+      currentY = ((e.clientY - rect.top) / rect.height) * videoHeight
+    }
 
     const deltaX = currentX - dragStart.x
     const deltaY = currentY - dragStart.y
@@ -508,12 +551,15 @@ export default function InteractiveBoundingBox({
           <div style={{ width: 'fit-content', display: 'flex', justifyContent: 'flex-start' }}>
             <Chip
               label={
-                isTypeAnnotation(annotation) ? annotation.typeCategory :
-                isObjectAnnotation(annotation) && annotation.linkedEntityId ? 'Entity' :
-                isObjectAnnotation(annotation) && annotation.linkedEventId ? 'Event' :
-                isObjectAnnotation(annotation) && annotation.linkedLocationId ? 'Location' :
-                isObjectAnnotation(annotation) && annotation.linkedCollectionId ? 'Collection' :
-                'Annotation'
+                // For type annotations: show actual type name, fallback to category
+                isTypeAnnotation(annotation) ? (typeName || annotation.typeCategory) :
+                // For object annotations: show object name, fallback to generic
+                linkedObject?.name ||
+                (isObjectAnnotation(annotation) && annotation.linkedEntityId ? 'Entity' :
+                 isObjectAnnotation(annotation) && annotation.linkedEventId ? 'Event' :
+                 isObjectAnnotation(annotation) && annotation.linkedLocationId ? 'Location' :
+                 isObjectAnnotation(annotation) && annotation.linkedCollectionId ? 'Collection' :
+                 'Annotation')
               }
               size="small"
               color={

--- a/annotation-tool/src/hooks/annotation/useAnnotationDrawing.test.tsx
+++ b/annotation-tool/src/hooks/annotation/useAnnotationDrawing.test.tsx
@@ -49,9 +49,9 @@ function setupStoreState(state: {
 }
 
 /**
- * Creates mock SVG element with getBoundingClientRect
+ * Creates mock SVG element with getBoundingClientRect and getAttribute
  */
-function createMockSvgRef(width = 800, height = 600): RefObject<SVGSVGElement> {
+function createMockSvgRef(width = 800, height = 600, videoWidth = 1920, videoHeight = 1080): RefObject<SVGSVGElement> {
   const mockElement = {
     getBoundingClientRect: vi.fn(() => ({
       left: 100,
@@ -64,6 +64,12 @@ function createMockSvgRef(width = 800, height = 600): RefObject<SVGSVGElement> {
       y: 50,
       toJSON: () => ({}),
     })),
+    getAttribute: vi.fn((attr: string) => {
+      if (attr === 'viewBox') {
+        return `0 0 ${videoWidth} ${videoHeight}`
+      }
+      return null
+    }),
   } as unknown as SVGSVGElement
 
   return { current: mockElement }
@@ -456,7 +462,8 @@ describe('useAnnotationDrawing', () => {
       // Check Zustand store state was reset
       const state = useAnnotationUiStore.getState()
       expect(state.temporaryBox).toBeNull()
-      expect(state.drawingMode).toBeNull()
+      // drawingMode is preserved for consecutive annotations (Bug #59 fix)
+      expect(state.drawingMode).toBe('entity')
     })
 
     it('should not create annotation with box too small', () => {

--- a/annotation-tool/src/hooks/annotation/useAnnotationDrawing.ts
+++ b/annotation-tool/src/hooks/annotation/useAnnotationDrawing.ts
@@ -95,8 +95,8 @@ interface UseAnnotationDrawingReturn {
 export function useAnnotationDrawing({
   videoId,
   currentTime,
-  videoWidth,
-  videoHeight,
+  videoWidth: _videoWidth,
+  videoHeight: _videoHeight,
   videoFps = 30,
 }: UseAnnotationDrawingParams): UseAnnotationDrawingReturn {
   const [isDrawing, setIsDrawing] = useState(false)
@@ -141,8 +141,10 @@ export function useAnnotationDrawing({
 
   /**
    * Convert mouse event coordinates to video coordinate space.
-   * Transforms screen pixel coordinates to video frame coordinates accounting for
-   * SVG viewBox scaling and viewport positioning.
+   * Uses SVG's native coordinate transformation matrix to correctly handle
+   * viewBox scaling and preserveAspectRatio (letterboxing/pillarboxing).
+   * Falls back to simple ratio calculation in test environments (jsdom) where
+   * SVG methods aren't fully implemented.
    *
    * @param e - Mouse event from SVG element
    * @param svgRef - Reference to SVG element
@@ -150,15 +152,35 @@ export function useAnnotationDrawing({
    */
   const getRelativeCoordinates = useCallback(
     (e: React.MouseEvent<SVGSVGElement>, svgRef: RefObject<SVGSVGElement>) => {
-      if (!svgRef.current) return { x: 0, y: 0 }
+      const svg = svgRef.current
+      if (!svg) return { x: 0, y: 0 }
 
-      const rect = svgRef.current.getBoundingClientRect()
-      return {
-        x: ((e.clientX - rect.left) / rect.width) * videoWidth,
-        y: ((e.clientY - rect.top) / rect.height) * videoHeight,
+      // Use SVG's native coordinate transformation matrix when available
+      // This correctly handles viewBox and preserveAspectRatio="xMidYMid meet"
+      if (typeof svg.createSVGPoint === 'function' && typeof svg.getScreenCTM === 'function') {
+        const ctm = svg.getScreenCTM()
+        if (ctm) {
+          const pt = svg.createSVGPoint()
+          pt.x = e.clientX
+          pt.y = e.clientY
+          const svgPoint = pt.matrixTransform(ctm.inverse())
+          return { x: svgPoint.x, y: svgPoint.y }
+        }
       }
+
+      // Fallback for test environments (jsdom) where SVG methods aren't available
+      const rect = svg.getBoundingClientRect()
+      const viewBox = typeof svg.getAttribute === 'function' ? svg.getAttribute('viewBox') : null
+      if (viewBox) {
+        const [, , vbWidth, vbHeight] = viewBox.split(' ').map(Number)
+        return {
+          x: ((e.clientX - rect.left) / rect.width) * vbWidth,
+          y: ((e.clientY - rect.top) / rect.height) * vbHeight,
+        }
+      }
+      return { x: e.clientX - rect.left, y: e.clientY - rect.top }
     },
-    [videoWidth, videoHeight]
+    []
   )
 
   /**

--- a/annotation-tool/src/store/zustand/annotationUiStore.test.ts
+++ b/annotation-tool/src/store/zustand/annotationUiStore.test.ts
@@ -103,7 +103,7 @@ describe('AnnotationUiStore', () => {
       expect(useAnnotationUiStore.getState().temporaryTime).toBe(null)
     })
 
-    it('should reset drawing state', () => {
+    it('should reset transient drawing state but preserve selection state', () => {
       const { setIsDrawing, setDrawingMode, setTemporaryBox, resetDrawingState } =
         useAnnotationUiStore.getState()
 
@@ -116,9 +116,11 @@ describe('AnnotationUiStore', () => {
       resetDrawingState()
 
       const state = useAnnotationUiStore.getState()
+      // Transient state should be reset
       expect(state.isDrawing).toBe(false)
-      expect(state.drawingMode).toBe(null)
       expect(state.temporaryBox).toBe(null)
+      // Selection state (drawingMode) should be preserved for consecutive annotations
+      expect(state.drawingMode).toBe('entity')
     })
   })
 

--- a/annotation-tool/src/store/zustand/annotationUiStore.ts
+++ b/annotation-tool/src/store/zustand/annotationUiStore.ts
@@ -335,9 +335,10 @@ export const useAnnotationUiStore = create<AnnotationUiState>()(
       resetDrawingState: () =>
         set({
           isDrawing: false,
-          drawingMode: null,
           temporaryBox: null,
           temporaryTime: null,
+          // Preserve drawingMode, selectedTypeId, selectedPersonaId, linkTargetId, linkTargetType
+          // to allow drawing multiple consecutive annotations without reselecting
         }, false, 'resetDrawingState'),
 
       resetSelectionState: () =>

--- a/annotation-tool/test/e2e/regression/annotation/bounding-box-fixes.spec.ts
+++ b/annotation-tool/test/e2e/regression/annotation/bounding-box-fixes.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect } from '../../fixtures/test-context.js'
+
+/**
+ * Regression tests for bounding box bug fixes (Issues #58, #59, #60).
+ * Tests coordinate positioning, selection persistence, and label/color consistency.
+ */
+
+test.describe('Bounding Box Position (Issue #58)', () => {
+  test.beforeEach(async ({ videoBrowser, testUser, testPersona, testEntityType, testVideo }) => {
+    await videoBrowser.navigateToHome()
+  })
+
+  test('bounding box appears at click position without offset', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+
+    // Draw a bounding box at a specific position
+    await annotationWorkspace.drawSimpleBoundingBox()
+    await annotationWorkspace.expectBoundingBoxVisible()
+
+    // Verify the box was created
+    const boxExists = await page.evaluate(() => {
+      const rect = document.querySelector('[data-testid="bounding-box"] rect')
+      return rect !== null
+    })
+    expect(boxExists).toBe(true)
+
+    // Get box position and verify it has valid coordinates
+    const boxCoords = await page.evaluate(() => {
+      const rect = document.querySelector('[data-testid="bounding-box"] rect')
+      if (!rect) return null
+      return {
+        x: parseFloat(rect.getAttribute('x') || '0'),
+        y: parseFloat(rect.getAttribute('y') || '0'),
+        width: parseFloat(rect.getAttribute('width') || '0'),
+        height: parseFloat(rect.getAttribute('height') || '0'),
+      }
+    })
+
+    expect(boxCoords).not.toBeNull()
+    expect(boxCoords!.x).toBeGreaterThanOrEqual(0)
+    expect(boxCoords!.y).toBeGreaterThanOrEqual(0)
+    expect(boxCoords!.width).toBeGreaterThan(5)
+    expect(boxCoords!.height).toBeGreaterThan(5)
+  })
+})
+
+test.describe('Selection Persistence (Issue #59)', () => {
+  test.beforeEach(async ({ videoBrowser, testUser, testPersona, testEntityType, testVideo }) => {
+    await videoBrowser.navigateToHome()
+  })
+
+  test('selection persists after drawing bounding box', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+
+    // Select persona and type
+    const personaSelect = page.getByRole('combobox', { name: /select persona/i })
+    await expect(personaSelect).toBeVisible({ timeout: 10000 })
+    await personaSelect.click()
+    await page.waitForTimeout(500)
+
+    const personaListbox = page.getByRole('listbox', { name: /select persona/i })
+    await expect(personaListbox).toBeVisible({ timeout: 5000 })
+    const personaOption = personaListbox.getByRole('option').filter({ hasNotText: /^None$/i }).first()
+    await personaOption.click()
+    await page.waitForTimeout(1000)
+
+    // Wait for type select to be enabled
+    const typeSelect = page.getByRole('combobox', { name: /select type/i })
+    await expect(typeSelect).toBeEnabled({ timeout: 30000 })
+    await typeSelect.click()
+    await page.waitForTimeout(500)
+    await typeSelect.press('ArrowDown')
+    await page.waitForTimeout(300)
+    await typeSelect.press('Enter')
+    await page.waitForTimeout(500)
+
+    // Draw first bounding box
+    await annotationWorkspace.drawBoundingBox({ x: 50, y: 50, width: 100, height: 100 })
+    await page.waitForTimeout(500)
+
+    // Verify cursor is still crosshair (selection preserved)
+    const cursor = await page.evaluate(() => {
+      const svg = document.querySelector('svg[viewBox]')
+      return svg ? getComputedStyle(svg).cursor : null
+    })
+    expect(cursor).toBe('crosshair')
+  })
+
+  test('can draw multiple consecutive boxes for same type', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+    await annotationWorkspace.drawSimpleBoundingBox()
+    await page.waitForTimeout(500)
+
+    // Cursor should still be crosshair for drawing more boxes
+    const cursor = await page.evaluate(() => {
+      const svg = document.querySelector('svg[viewBox]')
+      return svg ? getComputedStyle(svg).cursor : null
+    })
+    expect(cursor).toBe('crosshair')
+
+    // Draw another box without reselecting
+    await annotationWorkspace.drawBoundingBox({ x: 200, y: 50, width: 100, height: 100 })
+    await page.waitForTimeout(500)
+
+    // Verify at least two annotations were created
+    const annotationHeading = page.getByRole('heading', { name: /All Annotations/i })
+    await expect(annotationHeading).toContainText(/\([2-9]\d*\)/, { timeout: 5000 })
+  })
+})
+
+test.describe('Labels and Visual Distinction (Issue #60)', () => {
+  test.beforeEach(async ({ videoBrowser, testUser, testPersona, testEntityType, testVideo }) => {
+    await videoBrowser.navigateToHome()
+  })
+
+  test('type annotation shows actual type name in label', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+
+    // Select persona
+    const personaSelect = page.getByRole('combobox', { name: /select persona/i })
+    await expect(personaSelect).toBeVisible({ timeout: 10000 })
+    await personaSelect.click()
+    await page.waitForTimeout(500)
+
+    const personaListbox = page.getByRole('listbox', { name: /select persona/i })
+    await expect(personaListbox).toBeVisible({ timeout: 5000 })
+    const personaOption = personaListbox.getByRole('option').filter({ hasNotText: /^None$/i }).first()
+    await personaOption.click()
+    await page.waitForTimeout(1000)
+
+    // Select type and capture its name
+    const typeSelect = page.getByRole('combobox', { name: /select type/i })
+    await expect(typeSelect).toBeEnabled({ timeout: 30000 })
+    await typeSelect.click()
+    await page.waitForTimeout(500)
+
+    // Get the first option's text before selecting
+    const typeListbox = page.getByRole('listbox')
+    const typeOption = typeListbox.getByRole('option').first()
+    const expectedTypeName = await typeOption.textContent()
+    await typeOption.click()
+    await page.waitForTimeout(500)
+
+    // Draw bounding box
+    await annotationWorkspace.drawBoundingBox({ x: 50, y: 50, width: 100, height: 100 })
+    await page.waitForTimeout(500)
+
+    // Verify label shows the actual type name (e.g., "Test Entity Type", not "entity")
+    const label = page.locator('[data-testid="bounding-box"] .MuiChip-label')
+    await expect(label.first()).toBeVisible({ timeout: 5000 })
+
+    // The label should contain the type name, not just the category
+    const labelText = await label.first().textContent()
+    expect(labelText).toBeTruthy()
+    // The label should either match the expected type name or be a valid type name
+    // (not just "entity", "role", or "event")
+    expect(['entity', 'role', 'event']).not.toContain(labelText?.toLowerCase())
+  })
+
+  test('type annotation has correct color for its kind', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+    await annotationWorkspace.drawSimpleBoundingBox()
+    await page.waitForTimeout(500)
+
+    // Verify the stroke color indicates the kind
+    const strokeColor = await page.evaluate(() => {
+      const rect = document.querySelector('[data-testid="bounding-box"] rect')
+      return rect ? rect.getAttribute('stroke') : null
+    })
+
+    // Entity types should be green, events orange, roles blue
+    expect(['#4caf50', '#ff9800', '#2196f3']).toContain(strokeColor)
+  })
+
+  test('type annotations have thinner stroke than object annotations', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+    await annotationWorkspace.drawSimpleBoundingBox()
+    await page.waitForTimeout(500)
+
+    // Verify the stroke width for type annotation (should be 2px)
+    const strokeWidth = await page.evaluate(() => {
+      const rect = document.querySelector('[data-testid="bounding-box"] rect')
+      return rect ? rect.getAttribute('stroke-width') : null
+    })
+
+    // Type annotations should have stroke width of 2
+    expect(strokeWidth).toBe('2')
+  })
+})
+
+test.describe('Annotation Panel Consistency', () => {
+  test.beforeEach(async ({ videoBrowser, testUser, testPersona, testEntityType, testVideo }) => {
+    await videoBrowser.navigateToHome()
+  })
+
+  test('annotation panel shows colored chip for type annotations', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+    await annotationWorkspace.drawSimpleBoundingBox()
+    await page.waitForTimeout(500)
+
+    // Verify the annotation panel shows a colored chip
+    const listItem = page.locator('.MuiDrawer-root .MuiListItem-root').first()
+    const chip = listItem.locator('.MuiChip-root')
+    await expect(chip).toBeVisible({ timeout: 5000 })
+  })
+
+  test('type and object annotations have consistent colors between box and panel', async ({ annotationWorkspace, page, testUser, testPersona, testEntityType, testVideo }) => {
+    await annotationWorkspace.navigateFromVideoBrowser()
+    await annotationWorkspace.drawSimpleBoundingBox()
+    await page.waitForTimeout(500)
+
+    // Get bounding box stroke color
+    const boxStroke = await page.evaluate(() => {
+      const rect = document.querySelector('[data-testid="bounding-box"] rect')
+      return rect?.getAttribute('stroke')
+    })
+
+    // Get chip color from panel
+    const chipClass = await page.evaluate(() => {
+      const chip = document.querySelector('.MuiDrawer-root .MuiListItem-root .MuiChip-root')
+      return chip?.className
+    })
+
+    // Both should indicate the same kind
+    if (boxStroke === '#4caf50') {
+      // Entity - should be success color
+      expect(chipClass).toContain('MuiChip-colorSuccess')
+    } else if (boxStroke === '#ff9800') {
+      // Event - should be warning color
+      expect(chipClass).toContain('MuiChip-colorWarning')
+    } else if (boxStroke === '#2196f3') {
+      // Role - should be primary color
+      expect(chipClass).toContain('MuiChip-colorPrimary')
+    }
+  })
+})


### PR DESCRIPTION
## Description

Fixes three bounding box annotation bugs:
1. **Issue #58**: Boxes appear at offset from click position due to incorrect coordinate calculation that doesn't account for SVG letterboxing/pillarboxing
2. **Issue #59**: Selection state resets after drawing (must reselect persona/type) because `resetDrawingState()` cleared `drawingMode`
3. **Issue #60**: All labels show "entity" regardless of actual type - now shows actual type name with color indicating kind

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Fixes #58
Fixes #59
Fixes #60

## Changes Made

- Uses SVG's native `getScreenCTM()` and `createSVGPoint()` for accurate coordinate transformation in all 3 locations (useAnnotationDrawing.ts, InteractiveBoundingBox.tsx function and inline)
- Preserves `drawingMode` in `resetDrawingState()` to allow consecutive annotation drawing without reselecting
- Enriches type annotations with type name lookup from persona ontology
- Distinguishes type and object annotations by stroke width (2px vs 4px)
- Adds colored chips for object annotations in the annotation panel matching bounding box colors
- Adds E2E tests covering all three bug fixes

## Testing

### Test Environment

- OS: macOS Darwin 24.6.0
- Browser: Chrome (E2E tests via Playwright)
- Node version: v22.x

### Test Cases

- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [ ] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Navigate to annotation workspace with a video that has letterboxing (aspect ratio different from container)
2. Select a persona and type, draw a bounding box - verify it appears where you clicked (Issue #58)
3. After drawing, verify cursor remains crosshair and you can draw another box without reselecting (Issue #59)
4. Verify bounding box label shows actual type name (e.g., "Person") not just "entity" (Issue #60)
5. Verify type annotations have thinner stroke (2px) than object annotations (4px)
6. Verify annotation panel shows colored chips for object annotations

## Screenshots/Videos

N/A - behavioral bug fixes

## Documentation

- [x] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: The SVG matrix transformation is a native browser operation and has negligible performance overhead.

## Breaking Changes

**Breaking changes:**
- None

**Migration guide:**
- None required

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The coordinate fix uses SVG's native `getScreenCTM()` matrix transformation which correctly handles `preserveAspectRatio="xMidYMid meet"` (letterboxing/pillarboxing). A fallback using viewBox parsing is included for test environments (jsdom) where SVG methods aren't fully implemented.

The resize functionality is preserved because all 3 coordinate calculation locations were updated consistently - the delta-based resize math depends on relative differences, not absolute positions.

## Reviewer Guidance

Please verify that:
1. Bounding box resizing still works correctly (drag handles, maintaining proportions)
2. The coordinate transformation works with different aspect ratio videos
3. Type and object annotations are visually distinguishable