### PR TITLE
fix: Preserve GlossEditor input during rapid typing

### DIFF
--- a/annotation-tool/src/components/ontology/GlossEditor.test.tsx
+++ b/annotation-tool/src/components/ontology/GlossEditor.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import GlossEditor from './GlossEditor'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Mock the hooks
+vi.mock('@store/queries', () => ({
+  usePersonaOntology: () => ({ data: null }),
+  useWorld: () => ({ data: { entities: [], entityTypes: [], events: [], times: [] } }),
+  useAnnotations: () => ({ data: [] }),
+}))
+
+// Create a wrapper with QueryClientProvider
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('GlossEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('State Sync', () => {
+    it('does not reset input when typing rapidly', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <GlossEditor gloss={[]} onChange={onChange} />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+
+      // Type rapidly
+      await user.type(input, 'Hello World')
+
+      expect(input).toHaveValue('Hello World')
+    })
+
+    it('preserves input when component re-renders with same gloss', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <GlossEditor gloss={[]} onChange={onChange} personaId="test" />
+        </QueryClientProvider>
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'My text')
+
+      // Simulate re-render with same gloss (like when external data loads)
+      // Keep the same QueryClient to avoid remounting
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <GlossEditor gloss={[]} onChange={onChange} personaId="test" />
+        </QueryClientProvider>
+      )
+
+      expect(input).toHaveValue('My text')
+    })
+
+    it('updates input when gloss prop changes externally', async () => {
+      const onChange = vi.fn()
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <GlossEditor gloss={[]} onChange={onChange} />
+        </QueryClientProvider>
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toHaveValue('')
+
+      // Simulate external gloss change (e.g., loading saved data)
+      // Keep the same QueryClient to avoid remounting
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <GlossEditor
+            gloss={[{ type: 'text', content: 'External update' }]}
+            onChange={onChange}
+          />
+        </QueryClientProvider>
+      )
+
+      expect(input).toHaveValue('External update')
+    })
+
+    it('initializes with existing gloss content', () => {
+      const onChange = vi.fn()
+
+      render(
+        <GlossEditor
+          gloss={[{ type: 'text', content: 'Initial content' }]}
+          onChange={onChange}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toHaveValue('Initial content')
+    })
+
+    it('calls onChange with parsed gloss when typing', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <GlossEditor gloss={[]} onChange={onChange} />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, 'Test')
+
+      // onChange should be called for each character
+      expect(onChange).toHaveBeenCalledTimes(4)
+
+      // Last call should have the full text
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+      expect(lastCall).toEqual([{ type: 'text', content: 'Test' }])
+    })
+  })
+
+  describe('Autocomplete', () => {
+    it('shows autocomplete when # is typed', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <GlossEditor gloss={[]} onChange={onChange} />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '#')
+
+      // Should show autocomplete with types section
+      await waitFor(() => {
+        expect(screen.getByText(/No types found/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows autocomplete when @ is typed', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <GlossEditor gloss={[]} onChange={onChange} />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '@')
+
+      // Should show autocomplete with objects section
+      await waitFor(() => {
+        expect(screen.getByText(/No objects found/i)).toBeInTheDocument()
+      })
+    })
+
+    it('closes autocomplete when Escape is pressed', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <GlossEditor gloss={[]} onChange={onChange} />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '#')
+
+      // Autocomplete should be open
+      await waitFor(() => {
+        expect(screen.getByText(/No types found/i)).toBeInTheDocument()
+      })
+
+      // Press Escape
+      await user.keyboard('{Escape}')
+
+      // Autocomplete should be closed
+      await waitFor(() => {
+        expect(screen.queryByText(/No types found/i)).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables input when disabled prop is true', () => {
+      render(
+        <GlossEditor gloss={[]} onChange={vi.fn()} disabled={true} />,
+        { wrapper: createWrapper() }
+      )
+
+      const input = screen.getByRole('textbox')
+      expect(input).toBeDisabled()
+    })
+  })
+})

--- a/annotation-tool/src/components/ontology/GlossEditor.tsx
+++ b/annotation-tool/src/components/ontology/GlossEditor.tsx
@@ -71,6 +71,9 @@ export default function GlossEditor({
   const [autocompleteMode, setAutocompleteMode] = useState<'types' | 'objects' | 'annotations'>('types')
   const inputRef = useRef<HTMLInputElement>(null)
   const [cursorPosition, setCursorPosition] = useState(0)
+  // Track the last gloss prop we received to detect external changes
+  // Initialize with undefined to trigger initial sync
+  const lastGlossPropRef = useRef<GlossItem[] | undefined>(undefined)
 
   // Get all available types
   const allTypes: TypeOption[] = useMemo(() => [
@@ -383,10 +386,20 @@ export default function GlossEditor({
     return items
   }
 
-  // Initialize input value from gloss
+  // Initialize input value from gloss - only when gloss prop changes externally
   useEffect(() => {
-    setInputValue(glossToString(gloss))
-  }, [gloss, glossToString]) // Re-run when gloss or glossToString changes
+    // Check if gloss prop changed from what we last received
+    const glossPropChanged = JSON.stringify(gloss) !== JSON.stringify(lastGlossPropRef.current)
+
+    if (glossPropChanged) {
+      // Update input value from gloss prop
+      setInputValue(glossToString(gloss))
+      lastGlossPropRef.current = gloss
+    }
+    // Note: We only depend on gloss, not glossToString, to avoid resetting
+    // when external data (types/objects) loads and changes glossToString
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gloss])
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -440,7 +453,7 @@ export default function GlossEditor({
     
     const newValue = `${beforeText}${char}\`${item.name}\` ${afterText}`
     setInputValue(newValue)
-    
+
     const newGloss = stringToGloss(newValue)
     onChange(newGloss)
     


### PR DESCRIPTION
## Description

Fixes an issue where GlossEditor would reset user input during rapid typing due to a state sync anti-pattern. The useEffect was resetting inputValue whenever glossToString changed (due to async data loading), causing typed characters to be lost.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Fixes #68
Fixes #69

## Changes Made

- Added ref to track the last gloss prop value
- Modified useEffect to only sync from external prop changes, not internal updates
- Removed glossToString from dependency array to prevent resets during data loading

## Testing

### Test Environment

- OS: macOS
- Browser (if applicable): Chrome, Safari
- Node version: 23.x

### Test Cases

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Open video summary dialog
2. Type text rapidly in the summary editor
3. Verify all characters appear without being reset or lost

## Screenshots/Videos

N/A

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: N/A

## Breaking Changes

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

N/A

## Reviewer Guidance

Please test rapid typing in any GlossEditor field to verify input is preserved.