### PR TITLE
fix: Create session on registration so users stay logged in

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -364,6 +364,23 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         },
       })
 
+      // Create session so the user is logged in immediately after registration
+      const { token, expiresAt } = await authService.regenerateSession('', user.id, {
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        expiresInDays: 7,
+      })
+
+      recordSessionEvent('created')
+
+      reply.setCookie('session_token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        expires: expiresAt,
+        path: '/',
+      })
+
       return reply.code(201).send({
         user: {
           id: user.id,

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -502,6 +502,13 @@ describe('Authentication Routes', () => {
       expect(body.user.isAdmin).toBe(false)
       expect(body.user.passwordHash).toBeUndefined()
 
+      // Verify session cookie is set (user is logged in after registration)
+      const sessionCookie = response.cookies.find(
+        (c: { name: string }) => c.name === 'session_token'
+      )
+      expect(sessionCookie).toBeDefined()
+      expect(sessionCookie!.value).toBeTruthy()
+
       // Verify user created in database
       const user = await prisma.user.findUnique({
         where: { username: 'newuser' },
@@ -509,6 +516,12 @@ describe('Authentication Routes', () => {
       expect(user).toBeDefined()
       expect(user!.passwordHash).toBeDefined()
       expect(user!.passwordHash).not.toBe('securepass123') // Should be hashed
+
+      // Verify session created in database
+      const session = await prisma.session.findFirst({
+        where: { userId: user!.id },
+      })
+      expect(session).toBeDefined()
 
       // Clean up
       delete process.env.ALLOW_REGISTRATION


### PR DESCRIPTION
## Description

After registering, users appeared to be logged in (the frontend optimistically updated the auth store), but the server never created a session or set a `session_token` cookie. Every subsequent API call returned 401, effectively logging them out immediately. Logging in manually after registration worked fine because the login endpoint correctly creates a session.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Fixes #97

## Changes Made

- Added session creation (`authService.regenerateSession`) and cookie setting (`reply.setCookie`) to the `POST /api/auth/register` endpoint, mirroring the login endpoint's behavior
- Added test assertions to verify a session cookie is returned and a session record is created in the database on registration

## Testing

### Test Environment

- OS: macOS
- Node version: v22

### Test Cases

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Set `ALLOW_REGISTRATION=true` and `FOVEA_MODE=multi-user`
2. Register a new user via the registration form
3. Verify you remain logged in and can browse videos, access session-status, etc. without getting 401 errors

## Screenshots/Videos

N/A

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details:

## Breaking Changes

None.

**Breaking changes:**
-

**Migration guide:**
-

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The registration endpoint was creating the user in the database but returning the response without a session. The frontend's `register()` function called `loginSuccess(user)` which updated the local auth store, making it *appear* as though the user was logged in. But without a `session_token` cookie, the auth middleware rejected all subsequent requests.

## Reviewer Guidance

Compare the registration handler (lines 367-382 of `auth.ts`) with the login handler (lines 113-137) — they now follow the same session creation pattern.