### PR TITLE
feat: Prevent metadata-only modality selection in claim editor

### DIFF
--- a/annotation-tool/src/components/claims/ClaimEditor.test.tsx
+++ b/annotation-tool/src/components/claims/ClaimEditor.test.tsx
@@ -883,11 +883,11 @@ describe('ClaimEditor', () => {
     it('enables save when content, confidence, and modality are set', async () => {
       const user = userEvent.setup()
       render(<ClaimEditor {...defaultProps} />, { wrapper: createWrapper() })
-      
+
       // Enter content
       const input = screen.getByLabelText(/claim text with references/i)
       await user.type(input, 'Test claim')
-      
+
       // Select at least one modality
       const speechCheckbox = screen.getByLabelText('Speech', { selector: 'input' })
       await user.click(speechCheckbox)
@@ -897,6 +897,100 @@ describe('ClaimEditor', () => {
       await waitFor(() => {
         expect(saveButton).not.toBeDisabled()
       })
+    })
+
+    it('disables save when only metadata sources are selected', async () => {
+      const user = userEvent.setup()
+      render(<ClaimEditor {...defaultProps} />, { wrapper: createWrapper() })
+
+      // Enter content
+      const input = screen.getByLabelText(/claim text with references/i)
+      await user.type(input, 'Test claim')
+
+      // Select only metadata checkbox (no audio or video)
+      const metadataSection = screen.getByText(/Metadata Sources/i).parentElement?.parentElement
+      await user.click(within(metadataSection!).getByLabelText('Text', { selector: 'input' }))
+
+      // Save should be disabled because metadata-only is not allowed
+      const saveButton = screen.getByRole('button', { name: /create/i })
+      expect(saveButton).toBeDisabled()
+    })
+
+    it('enables save when metadata plus audio source is selected', async () => {
+      const user = userEvent.setup()
+      render(<ClaimEditor {...defaultProps} />, { wrapper: createWrapper() })
+
+      // Enter content
+      const input = screen.getByLabelText(/claim text with references/i)
+      await user.type(input, 'Test claim')
+
+      // Select metadata checkbox
+      const metadataSection = screen.getByText(/Metadata Sources/i).parentElement?.parentElement
+      await user.click(within(metadataSection!).getByLabelText('Text', { selector: 'input' }))
+
+      // Also select an audio checkbox
+      const speechCheckbox = screen.getByLabelText('Speech', { selector: 'input' })
+      await user.click(speechCheckbox)
+
+      // Save should be enabled since we have audio + metadata
+      const saveButton = screen.getByRole('button', { name: /create/i })
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled()
+      })
+    })
+
+    it('enables save when metadata plus video source is selected', async () => {
+      const user = userEvent.setup()
+      render(<ClaimEditor {...defaultProps} />, { wrapper: createWrapper() })
+
+      // Enter content
+      const input = screen.getByLabelText(/claim text with references/i)
+      await user.type(input, 'Test claim')
+
+      // Select metadata checkbox
+      const metadataSection = screen.getByText(/Metadata Sources/i).parentElement?.parentElement
+      await user.click(within(metadataSection!).getByLabelText('Non-text', { selector: 'input' }))
+
+      // Also select a video checkbox
+      const videoSection = screen.getByText(/Video Sources/i).parentElement?.parentElement
+      await user.click(within(videoSection!).getByLabelText('Non-text', { selector: 'input' }))
+
+      // Save should be enabled since we have video + metadata
+      const saveButton = screen.getByRole('button', { name: /create/i })
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled()
+      })
+    })
+
+    it('shows warning when only metadata sources are selected', async () => {
+      const user = userEvent.setup()
+      render(<ClaimEditor {...defaultProps} />, { wrapper: createWrapper() })
+
+      // Select only metadata checkbox
+      const metadataSection = screen.getByText(/Metadata Sources/i).parentElement?.parentElement
+      await user.click(within(metadataSection!).getByLabelText('Text', { selector: 'input' }))
+
+      // Warning message should appear
+      expect(screen.getByText(/Metadata sources cannot be the only selection/i)).toBeInTheDocument()
+    })
+
+    it('hides warning when audio or video source is added', async () => {
+      const user = userEvent.setup()
+      render(<ClaimEditor {...defaultProps} />, { wrapper: createWrapper() })
+
+      // Select only metadata checkbox
+      const metadataSection = screen.getByText(/Metadata Sources/i).parentElement?.parentElement
+      await user.click(within(metadataSection!).getByLabelText('Text', { selector: 'input' }))
+
+      // Warning should be visible
+      expect(screen.getByText(/Metadata sources cannot be the only selection/i)).toBeInTheDocument()
+
+      // Add an audio source
+      const speechCheckbox = screen.getByLabelText('Speech', { selector: 'input' })
+      await user.click(speechCheckbox)
+
+      // Warning should disappear
+      expect(screen.queryByText(/Metadata sources cannot be the only selection/i)).not.toBeInTheDocument()
     })
   })
 

--- a/annotation-tool/src/components/claims/ClaimEditor.tsx
+++ b/annotation-tool/src/components/claims/ClaimEditor.tsx
@@ -241,10 +241,13 @@ export default function ClaimEditor({
   const hasContent = gloss.some(item => item.content.trim().length > 0)
   // Check if at least one modality checkbox is checked
   const hasModalityMetadata = audio.length > 0 || video.length > 0 || metadata.length > 0
+  // Metadata sources alone are not sufficient - must have at least one audio or video source
+  const hasNonMetadataSource = audio.length > 0 || video.length > 0
+  const metadataOnly = metadata.length > 0 && !hasNonMetadataSource
   // Check if confidence is set (should always be set, but validate anyway)
   const hasConfidence = confidence !== undefined
-  // Validation: content, confidence, and modality are required
-  const isValid = hasContent && hasConfidence && hasModalityMetadata
+  // Validation: content, confidence, and modality are required; metadata-only is not allowed
+  const isValid = hasContent && hasConfidence && hasModalityMetadata && !metadataOnly
 
   // Track validation state to log failures only when user attempts to save
   const previousValidationAttemptRef = useRef<boolean>(false)
@@ -262,6 +265,7 @@ export default function ClaimEditor({
           hasContent,
           hasConfidence,
           hasModalityMetadata,
+          metadataOnly,
           glossLength: gloss.length,
         })
         previousValidationAttemptRef.current = true
@@ -269,7 +273,7 @@ export default function ClaimEditor({
     } else {
       previousValidationAttemptRef.current = false
     }
-  }, [isValid, hasContent, hasConfidence, hasModalityMetadata, summaryId, claim?.id, gloss.length, open])
+  }, [isValid, hasContent, hasConfidence, hasModalityMetadata, metadataOnly, summaryId, claim?.id, gloss.length, open])
 
   return (
     <Dialog
@@ -333,8 +337,13 @@ export default function ClaimEditor({
               Modality Metadata *
             </Typography>
             <Typography variant="caption" color="text.secondary" sx={{ mb: 1.5, display: 'block' }}>
-              Indicate what sources support this claim. You can select multiple options for each field. At least one option must be selected.
+              Indicate what sources support this claim. You can select multiple options for each field. At least one audio or video source must be selected.
             </Typography>
+            {metadataOnly && (
+              <Typography variant="caption" color="error" sx={{ mb: 1.5, display: 'block' }}>
+                Please select at least one audio or video source. Metadata sources cannot be the only selection.
+              </Typography>
+            )}
             <Box sx={{ display: 'flex', gap: 2 }}>
               {/* Audio Modality */}
               <Box sx={{ flex: '1 1 33%', minWidth: 0 }}>


### PR DESCRIPTION
## Description

Prevents users from selecting only metadata sources for modality metadata when creating or editing claims. At least one audio or video source must also be selected. Shows an inline error message when only metadata checkboxes are selected.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Fixes #96
Relates to #

## Changes Made

- Added `metadataOnly` validation check to `ClaimEditor.tsx` that prevents saving when only metadata sources are selected
- Updated help text to communicate the constraint
- Added inline error message that appears when only metadata is selected
- Added 6 new test cases covering metadata-only validation, combined sources, and warning visibility

## Testing

### Test Environment

- OS: macOS
- Node version: v22

### Test Cases

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Open the claim editor dialog
2. Select only metadata checkboxes (Text or Non-text under Metadata Sources)
3. Verify the Save/Create button is disabled and warning text appears
4. Select an audio or video source checkbox
5. Verify the warning disappears and Save/Create becomes enabled

## Screenshots/Videos

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details:

## Breaking Changes

**Breaking changes:**
-

**Migration guide:**
-

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

## Reviewer Guidance

The core change is just 3 lines of validation logic in ClaimEditor.tsx (lines 245-246, 249). The rest is the error message UI and tests.