### PR TITLE
fix: Generate new UUIDs for cross-user imports when original IDs absent from DB

### DIFF
--- a/server/src/services/import-handler.ts
+++ b/server/src/services/import-handler.ts
@@ -53,6 +53,7 @@ interface AnnotationData {
 
 interface PersonaData {
   id: string
+  userId?: string
   [key: string]: unknown
 }
 
@@ -434,6 +435,19 @@ export class ImportHandler {
   async detectConflicts(lines: ImportLine[], existingData: ExistingData): Promise<Conflict[]> {
     const conflicts: Conflict[] = []
 
+    // Identify foreign persona IDs from import data: personas whose userId
+    // differs from the importing user. These need new UUIDs even if their IDs
+    // don't already exist in the database.
+    const foreignPersonaIds = new Set<string>()
+    for (const line of lines) {
+      if (line.type === 'persona') {
+        const personaData = line.data as PersonaData
+        if (personaData.userId && personaData.userId !== this.userId) {
+          foreignPersonaIds.add(personaData.id)
+        }
+      }
+    }
+
     for (const line of lines) {
       switch (line.type) {
         case 'persona': {
@@ -446,6 +460,14 @@ export class ImportHandler {
               existingId: personaData.id,
               details: `Persona with ID ${personaData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(personaData.id, 'persona', existingData)
+            })
+          } else if (foreignPersonaIds.has(personaData.id)) {
+            conflicts.push({
+              type: 'duplicate-persona',
+              line: line.lineNumber,
+              originalId: personaData.id,
+              details: `Persona from a different user requires new ID`,
+              ownedByImporter: false
             })
           }
           break
@@ -470,6 +492,14 @@ export class ImportHandler {
               frameRange,
               interpolationType: (sequence.interpolationSegments as Array<{ type?: string }>)[0]?.type,
               ownedByImporter: this.isOwnedByImporter(annotationData.id, 'annotation', existingData)
+            })
+          } else if (annotationData.personaId && foreignPersonaIds.has(annotationData.personaId)) {
+            conflicts.push({
+              type: 'duplicate-sequence',
+              line: line.lineNumber,
+              originalId: annotationData.id,
+              details: `Annotation from a different user requires new ID`,
+              ownedByImporter: false
             })
           }
 
@@ -505,6 +535,14 @@ export class ImportHandler {
               details: `Entity with ID ${entityData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(entityData.id, 'entity', existingData)
             })
+          } else if (foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-object',
+              line: line.lineNumber,
+              originalId: entityData.id,
+              details: `Entity from a different user requires new ID`,
+              ownedByImporter: false
+            })
           }
           break
         }
@@ -520,6 +558,14 @@ export class ImportHandler {
               details: `Event with ID ${eventData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(eventData.id, 'event', existingData)
             })
+          } else if (foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-object',
+              line: line.lineNumber,
+              originalId: eventData.id,
+              details: `Event from a different user requires new ID`,
+              ownedByImporter: false
+            })
           }
           break
         }
@@ -534,6 +580,14 @@ export class ImportHandler {
               existingId: timeData.id,
               details: `Time with ID ${timeData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(timeData.id, 'time', existingData)
+            })
+          } else if (foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-object',
+              line: line.lineNumber,
+              originalId: timeData.id,
+              details: `Time from a different user requires new ID`,
+              ownedByImporter: false
             })
           }
           break
@@ -555,6 +609,14 @@ export class ImportHandler {
               details: `Collection with ID ${collectionData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(collectionData.id, line.type, existingData)
             })
+          } else if (foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-object',
+              line: line.lineNumber,
+              originalId: collectionData.id,
+              details: `Collection from a different user requires new ID`,
+              ownedByImporter: false
+            })
           }
           break
         }
@@ -570,12 +632,20 @@ export class ImportHandler {
               details: `Relation with ID ${relationData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(relationData.id, 'relation', existingData)
             })
+          } else if (relationData.id && foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-object',
+              line: line.lineNumber,
+              originalId: relationData.id,
+              details: `Relation from a different user requires new ID`,
+              ownedByImporter: false
+            })
           }
           break
         }
 
         case 'summary': {
-          const summaryData = line.data as { id: string; [key: string]: unknown }
+          const summaryData = line.data as { id: string; personaId?: string; [key: string]: unknown }
           if (summaryData.id && existingData.summaryIds.has(summaryData.id)) {
             conflicts.push({
               type: 'duplicate-summary',
@@ -584,6 +654,14 @@ export class ImportHandler {
               existingId: summaryData.id,
               details: `Summary with ID ${summaryData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(summaryData.id, 'summary', existingData)
+            })
+          } else if (summaryData.id && summaryData.personaId && foreignPersonaIds.has(summaryData.personaId)) {
+            conflicts.push({
+              type: 'duplicate-summary',
+              line: line.lineNumber,
+              originalId: summaryData.id,
+              details: `Summary from a different user requires new ID`,
+              ownedByImporter: false
             })
           }
           break
@@ -600,6 +678,14 @@ export class ImportHandler {
               details: `Claim with ID ${claimData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(claimData.id, 'claim', existingData)
             })
+          } else if (claimData.id && foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-claim',
+              line: line.lineNumber,
+              originalId: claimData.id,
+              details: `Claim from a different user requires new ID`,
+              ownedByImporter: false
+            })
           }
           break
         }
@@ -614,6 +700,14 @@ export class ImportHandler {
               existingId: relationData.id,
               details: `Claim relation with ID ${relationData.id} already exists`,
               ownedByImporter: this.isOwnedByImporter(relationData.id, 'claim_relation', existingData)
+            })
+          } else if (relationData.id && foreignPersonaIds.size > 0) {
+            conflicts.push({
+              type: 'duplicate-claim-relation',
+              line: line.lineNumber,
+              originalId: relationData.id,
+              details: `Claim relation from a different user requires new ID`,
+              ownedByImporter: false
             })
           }
           break

--- a/server/test/integration/import-export-cross-user.test.ts
+++ b/server/test/integration/import-export-cross-user.test.ts
@@ -256,6 +256,64 @@ describe('Cross-user import/export round-trip', () => {
     expect(userBExportedPersonas[0].data.userId).toBe(userBId)
   })
 
+  it('cross-user import generates new IDs even when original IDs are absent from DB', async () => {
+    // Step 1: User A exports
+    const exportResponse = await app.inject({
+      method: 'GET',
+      url: '/api/export',
+      cookies: { session_token: userASessionToken },
+    })
+    expect(exportResponse.statusCode).toBe(200)
+    const exportedJsonl = exportResponse.body
+
+    // Collect user A's original IDs from the export
+    const exportedLines = exportedJsonl.trim().split('\n').filter((l: string) => l).map((l: string) => JSON.parse(l))
+    const originalPersonaIds = exportedLines
+      .filter((e: { type: string }) => e.type === 'persona')
+      .map((e: { data: { id: string } }) => e.data.id)
+    const originalAnnotationIds = exportedLines
+      .filter((e: { type: string }) => e.type === 'annotation')
+      .map((e: { data: { id: string } }) => e.data.id)
+
+    // Step 2: Delete user A's data so IDs no longer exist in the DB
+    await prisma.claimRelation.deleteMany()
+    await prisma.claim.deleteMany()
+    await prisma.annotation.deleteMany({ where: { persona: { userId: userAId } } })
+    await prisma.videoSummary.deleteMany({ where: { persona: { userId: userAId } } })
+    await prisma.ontology.deleteMany({ where: { persona: { userId: userAId } } })
+    await prisma.worldState.deleteMany({ where: { userId: userAId } })
+    await prisma.persona.deleteMany({ where: { userId: userAId } })
+
+    // Step 3: User B imports user A's export (IDs no longer in DB)
+    const { body, contentType } = createImportForm(exportedJsonl)
+    const importResponse = await app.inject({
+      method: 'POST',
+      url: '/api/import',
+      cookies: { session_token: userBSessionToken },
+      headers: { 'content-type': contentType },
+      payload: body,
+    })
+
+    expect(importResponse.statusCode).toBe(200)
+    const result = importResponse.json()
+    expect(result.success).toBe(true)
+
+    // Step 4: Verify user B has new IDs (not the originals from user A)
+    const userBPersonas = await prisma.persona.findMany({ where: { userId: userBId } })
+    expect(userBPersonas.length).toBeGreaterThanOrEqual(1)
+    for (const persona of userBPersonas) {
+      expect(originalPersonaIds).not.toContain(persona.id)
+    }
+
+    const userBAnnotations = await prisma.annotation.findMany({
+      where: { personaId: { in: userBPersonas.map(p => p.id) } },
+    })
+    expect(userBAnnotations.length).toBeGreaterThanOrEqual(1)
+    for (const annotation of userBAnnotations) {
+      expect(originalAnnotationIds).not.toContain(annotation.id)
+    }
+  })
+
   it('user A re-importing own export does not create duplicates', async () => {
     // Step 1: User A exports
     const exportResponse = await app.inject({

--- a/server/test/services/import-cross-user.test.ts
+++ b/server/test/services/import-cross-user.test.ts
@@ -231,21 +231,41 @@ describe('Cross-user import ownership', () => {
       expect(conflicts[0].ownedByImporter).toBe(false)
     })
 
-    it('should produce no conflicts for IDs that do not exist yet', async () => {
+    it('should produce no conflicts for new IDs from the same user', async () => {
       const existingData = createEmptyExistingData()
 
       const lines: ImportLine[] = [
-        { type: 'persona', data: { id: 'new-persona' }, lineNumber: 1 },
+        { type: 'persona', data: { id: 'new-persona', userId: USER_B }, lineNumber: 1 },
         createAnnotationLine('new-ann', 'new-persona', 'vid-1', 2),
         { type: 'entity', data: { id: 'new-ent' }, lineNumber: 3 },
-        { type: 'summary', data: { id: 'new-sum', videoId: 'vid-1' }, lineNumber: 4 },
+        { type: 'summary', data: { id: 'new-sum', videoId: 'vid-1', personaId: 'new-persona' }, lineNumber: 4 },
       ]
 
       const conflicts = await handlerB.detectConflicts(lines, existingData)
 
-      // Only missing-dependency conflicts are possible (no duplicate IDs)
+      // Only missing-dependency conflicts are possible (same user, no duplicate IDs)
       const duplicateConflicts = conflicts.filter(c => !c.type.startsWith('missing'))
       expect(duplicateConflicts).toHaveLength(0)
+    })
+
+    it('should produce foreign-data conflicts for new IDs from a different user', async () => {
+      const existingData = createEmptyExistingData()
+
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'new-persona', userId: USER_A }, lineNumber: 1 },
+        createAnnotationLine('new-ann', 'new-persona', 'vid-1', 2),
+        { type: 'entity', data: { id: 'new-ent' }, lineNumber: 3 },
+        { type: 'summary', data: { id: 'new-sum', videoId: 'vid-1', personaId: 'new-persona' }, lineNumber: 4 },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(lines, existingData)
+
+      // Foreign persona, annotation, entity, and summary should all have conflicts
+      const foreignConflicts = conflicts.filter(c => c.ownedByImporter === false)
+      expect(foreignConflicts.length).toBeGreaterThanOrEqual(4)
+      for (const conflict of foreignConflicts) {
+        expect(conflict.ownedByImporter).toBe(false)
+      }
     })
   })
 


### PR DESCRIPTION
## Description

When importing annotations exported by a different user into a new account, the import handler only generated new UUIDs for items whose IDs already existed in the database (conflict path). If the original IDs were absent (e.g., importing into a fresh account or after the original user's data was deleted), items were imported with the original UUIDs, causing ownership confusion and potential conflicts on re-import.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Fixes #100
Relates to #

## Changes Made

- Added a pre-scan in `detectConflicts` that identifies foreign persona IDs from the import data by comparing the exported `userId` field against the importing user's ID
- For every item type (persona, annotation, entity, event, time, collection, relation, summary, claim, claim relation), if the ID doesn't already exist in the DB but is associated with a foreign persona, a conflict with `ownedByImporter: false` is now emitted
- The existing `resolveConflicts` method already handles `ownedByImporter: false` by forcing `create-new` with a new UUID, so no changes were needed there

## Testing

### Test Environment

- OS: macOS
- Node version: 22

### Test Cases

- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [ ] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Export annotations from user A
2. Delete user A's data (or register as a new user B on a fresh instance)
3. Import user A's export as user B
4. Verify that all imported items have new UUIDs, not the originals from user A

## Screenshots/Videos

N/A

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: Adds one additional pass over persona lines at the start of `detectConflicts`, which is negligible compared to the database queries already performed.

## Breaking Changes

**Breaking changes:**
- None

**Migration guide:**
- N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The fix relies on the `userId` field already present in exported persona data. If an import file lacks `userId` on personas (e.g., manually constructed JSONL), the behavior falls back to the previous logic (only conflict-based detection).

## Reviewer Guidance

Focus on `import-handler.ts` lines 437-460 where the `foreignPersonaIds` set is built, and the `else if` branches added to each case in `detectConflicts`.