### PR TITLE
fix: close cross-user UUID regeneration gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-04-15
+
+### Fixed
+
+- Regenerates IDs for cross-user imports whose exports contain no persona lines (for example, users who only create object annotations linked to world entities)
+- Remaps array-valued ID reference fields (`entityIds`, `eventIds`) on entity and event collections during cross-user imports
+- Remaps `GlossItem.content` for `objectRef`, `annotationRef`, `claimRef`, and instance-level `typeRef` items so claims citing regenerated objects follow their new UUIDs
+- Lets cross-user ID regeneration override non-regenerating resolutions (`skip`, `replace`, `merge`) so annotations referencing entities in the same import batch get new IDs
+
+### Added
+
+- Emits a provenance `metadata` line with `exporterUserId` at the start of every full export for reliable cross-user detection
+- Emits `userId` on exported object annotations so cross-user detection works for exports that contain no persona lines
+- Import dialog now shows a cross-user banner, per-conflict smart defaults, an "apply to all" bulk resolution, and auto-collapses large conflict groups
+
 ## [0.1.6] - 2026-03-28
 
 ### Fixed

--- a/annotation-tool/package.json
+++ b/annotation-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fovea/annotation-tool",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/annotation-tool/src/components/data-management/ImportDataDialog.tsx
+++ b/annotation-tool/src/components/data-management/ImportDataDialog.tsx
@@ -129,10 +129,22 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
   }, [open])
 
   /**
-   * Get default resolution for a conflict type.
+   * Check if the preview contains foreign (cross-user) data.
    */
-  const getDefaultResolution = (conflictType: Conflict['type']): string => {
-    switch (conflictType) {
+  const hasForeignData = (previewData: ImportPreview): boolean => {
+    return previewData.conflicts.some(c => c.ownedByImporter === false)
+  }
+
+  /**
+   * Get default resolution for a conflict type.
+   * Foreign data defaults to 'create-new' so the import creates copies.
+   */
+  const getDefaultResolution = (conflict: Conflict): string => {
+    if (conflict.ownedByImporter === false) {
+      return 'create-new'
+    }
+
+    switch (conflict.type) {
       case 'duplicate-sequence':
         return 'skip'
       case 'overlapping-frames':
@@ -143,6 +155,9 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
         return 'skip-item'
       case 'duplicate-persona':
       case 'duplicate-object':
+      case 'duplicate-summary':
+      case 'duplicate-claim':
+      case 'duplicate-claim-relation':
       case 'id-conflict':
         return 'skip'
       default:
@@ -166,7 +181,7 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
       // Initialize conflict resolutions with defaults
       const resolutions = new Map<string, string>()
       for (const conflict of previewData.conflicts) {
-        resolutions.set(conflict.originalId, getDefaultResolution(conflict.type))
+        resolutions.set(conflict.originalId, getDefaultResolution(conflict))
       }
       setConflictResolutions(resolutions)
     } catch (error: unknown) {
@@ -248,12 +263,25 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
   }
 
   /**
-   * Update conflict resolution strategy.
+   * Update conflict resolution strategy for a single conflict.
    */
   const updateConflictResolution = (conflictId: string, resolution: string) => {
     setConflictResolutions(prev => {
       const newMap = new Map(prev)
       newMap.set(conflictId, resolution)
+      return newMap
+    })
+  }
+
+  /**
+   * Apply a resolution strategy to all conflicts of a given type.
+   */
+  const applyToAllConflicts = (conflicts: Conflict[], resolution: string) => {
+    setConflictResolutions(prev => {
+      const newMap = new Map(prev)
+      for (const conflict of conflicts) {
+        newMap.set(conflict.originalId, resolution)
+      }
       return newMap
     })
   }
@@ -383,6 +411,27 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
    */
   const getResolutionOptions = (conflictType: Conflict['type']): Array<{ value: string; label: string }> => {
     switch (conflictType) {
+      case 'duplicate-persona':
+        return [
+          { value: 'skip', label: 'Skip (keep existing)' },
+          { value: 'replace', label: 'Replace with imported' },
+          { value: 'merge', label: 'Merge fields' },
+          { value: 'create-new', label: 'Create as new copy' },
+        ]
+      case 'duplicate-object':
+        return [
+          { value: 'skip', label: 'Skip (keep existing)' },
+          { value: 'replace', label: 'Replace with imported' },
+          { value: 'merge-assignments', label: 'Merge assignments' },
+          { value: 'create-new', label: 'Create as new copy' },
+        ]
+      case 'duplicate-summary':
+      case 'duplicate-claim':
+      case 'duplicate-claim-relation':
+        return [
+          { value: 'skip', label: 'Skip (keep existing)' },
+          { value: 'create-new', label: 'Create as new copy' },
+        ]
       case 'duplicate-sequence':
         return [
           { value: 'skip', label: 'Skip (keep existing)' },
@@ -478,6 +527,9 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
       case 'missing-dependency': return 'Missing Dependencies'
       case 'duplicate-persona': return 'Duplicate Personas'
       case 'duplicate-object': return 'Duplicate Objects'
+      case 'duplicate-summary': return 'Duplicate Summaries'
+      case 'duplicate-claim': return 'Duplicate Claims'
+      case 'duplicate-claim-relation': return 'Duplicate Claim Relations'
       case 'id-conflict': return 'ID Conflicts'
       default: return 'Other Conflicts'
     }
@@ -889,19 +941,46 @@ export default function ImportDataDialog({ open, onClose, onImportComplete }: Im
                 {/* Conflicts */}
                 {preview.conflicts.length > 0 && (
                   <Box>
+                    {hasForeignData(preview) && (
+                      <Alert severity="info" icon={<InfoIcon />} sx={{ mb: 2 }}>
+                        This file contains data from another user. Conflicting items
+                        default to "Create as new copy" so they are imported with new
+                        IDs under your account.
+                      </Alert>
+                    )}
+
                     <Alert severity="warning" icon={<WarningIcon />} sx={{ mb: 2 }}>
                       {preview.conflicts.length} conflict{preview.conflicts.length !== 1 ? 's' : ''} detected.
                       Please select resolution strategies below.
                     </Alert>
 
                     {Array.from(groupConflictsByType(preview.conflicts)).map(([type, conflicts]) => (
-                      <Accordion key={type} defaultExpanded>
+                      <Accordion key={type} defaultExpanded={conflicts.length <= 10}>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                           <Typography>
                             {getConflictTypeName(type)} ({conflicts.length})
                           </Typography>
                         </AccordionSummary>
                         <AccordionDetails>
+                          {conflicts.length > 1 && (
+                            <Box sx={{ mb: 2, pb: 2, borderBottom: 1, borderColor: 'divider' }}>
+                              <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                                Apply to all {conflicts.length} items:
+                              </Typography>
+                              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                                {getResolutionOptions(type).map(opt => (
+                                  <Button
+                                    key={opt.value}
+                                    size="small"
+                                    variant="outlined"
+                                    onClick={() => applyToAllConflicts(conflicts, opt.value)}
+                                  >
+                                    {opt.label}
+                                  </Button>
+                                ))}
+                              </Box>
+                            </Box>
+                          )}
                           {conflicts.map(renderConflict)}
                         </AccordionDetails>
                       </Accordion>

--- a/annotation-tool/src/models/export-import.ts
+++ b/annotation-tool/src/models/export-import.ts
@@ -262,7 +262,8 @@ export interface ImportOptions {
 export interface Conflict {
   /** Type of conflict */
   type: 'duplicate-persona' | 'duplicate-object' | 'missing-dependency' | 'id-conflict' |
-        'duplicate-sequence' | 'overlapping-frames' | 'interpolation-conflict'
+        'duplicate-sequence' | 'overlapping-frames' | 'interpolation-conflict' |
+        'duplicate-summary' | 'duplicate-claim' | 'duplicate-claim-relation'
   /** Line number in the import file */
   line: number
   /** ID of the object being imported */
@@ -275,6 +276,8 @@ export interface Conflict {
   frameRange?: { start: number; end: number }
   /** Interpolation type involved (for interpolation conflicts) */
   interpolationType?: string
+  /** Whether the conflicting item is owned by the importing user */
+  ownedByImporter?: boolean
 }
 
 /**

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fovea/server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/src/services/export-handler.ts
+++ b/server/src/services/export-handler.ts
@@ -175,6 +175,7 @@ export class AnnotationExporter {
         notes?: string
         metadata?: Record<string, unknown>
         createdBy?: string
+        userId?: string
       }
     }
 
@@ -204,6 +205,10 @@ export class AnnotationExporter {
         exportData.data.linkedCollectionId = annotation.linkedCollectionId
         exportData.data.linkedCollectionType = annotation.linkedCollectionType
       }
+      // Object annotations can exist without a persona; emit the owning
+      // userId so cross-user detection works for exports that contain
+      // no persona lines at all.
+      if (annotation.userId) exportData.data.userId = annotation.userId
     }
 
     // Add optional fields
@@ -268,6 +273,7 @@ export class AnnotationExporter {
         notes?: string
         metadata?: Record<string, unknown>
         createdBy?: string
+        userId?: string
       }
     }
 
@@ -297,6 +303,10 @@ export class AnnotationExporter {
         exportData.data.linkedCollectionId = annotation.linkedCollectionId
         exportData.data.linkedCollectionType = annotation.linkedCollectionType
       }
+      // Object annotations can exist without a persona; emit the owning
+      // userId so cross-user detection works for exports that contain
+      // no persona lines at all.
+      if (annotation.userId) exportData.data.userId = annotation.userId
     }
 
     // Add optional fields
@@ -929,6 +939,19 @@ export class AnnotationExporter {
    */
   async exportAll(prisma: PrismaClient, userId: string): Promise<string> {
     const lines: string[] = []
+
+    // 0. Provenance metadata. Importers rely on exporterUserId to detect
+    // cross-user imports even when the export contains no persona lines
+    // (e.g. users who only produce object annotations linked to world
+    // state, with no persona or ontology).
+    lines.push(JSON.stringify({
+      type: 'metadata',
+      data: {
+        exporterUserId: userId,
+        exportVersion: '1.0',
+        exportedAt: new Date().toISOString(),
+      },
+    }))
 
     // 1. Export personas with ontologies
     const personas = await prisma.persona.findMany({

--- a/server/src/services/export-handler.ts
+++ b/server/src/services/export-handler.ts
@@ -78,6 +78,7 @@ interface Annotation {
   notes?: string
   metadata?: Record<string, unknown>
   createdBy?: string
+  userId?: string
   createdAt: string
   updatedAt: string
 }

--- a/server/src/services/import-handler.ts
+++ b/server/src/services/import-handler.ts
@@ -888,16 +888,38 @@ export class ImportHandler {
       return obj.map(item => this.remapObjectIds(item, idMap)) as unknown as ImportLine['data']
     } else if (obj && typeof obj === 'object') {
       const remapped: ImportLine['data'] = {}
+      // GlossItem references store the target ID in `content` rather than a
+      // *Id-suffixed key; detect these so the content is rewritten too.
+      const glossType = (obj as Record<string, unknown>).type
+      const glossRefType = (obj as Record<string, unknown>).refType
+      const isObjectRef = glossType === 'objectRef' || glossType === 'annotationRef' || glossType === 'claimRef'
+      const isInstanceTypeRef = glossType === 'typeRef' && typeof glossRefType === 'string' &&
+        (glossRefType === 'entity-object' || glossRefType === 'event-object' ||
+         glossRefType === 'time-object' || glossRefType === 'location-object' ||
+         glossRefType === 'annotation' || glossRefType === 'claim')
+
       for (const [key, value] of Object.entries(obj)) {
-        // Remap ID fields
+        // Scalar id field
         if (key === 'id' && typeof value === 'string' && idMap.has(value)) {
           remapped[key] = idMap.get(value)
         }
-        // Remap reference fields
-        else if ((key.endsWith('Id') || key.endsWith('Ids')) && typeof value === 'string' && idMap.has(value)) {
+        // Scalar *Id reference field
+        else if (key.endsWith('Id') && typeof value === 'string' && idMap.has(value)) {
           remapped[key] = idMap.get(value)
         }
-        // Recurse into nested objects
+        // Array of IDs (e.g. entityIds: string[], eventIds: string[])
+        else if (key.endsWith('Ids') && Array.isArray(value) && value.every(v => typeof v === 'string')) {
+          remapped[key] = (value as string[]).map(v => idMap.get(v) ?? v)
+        }
+        // Scalar *Ids stored as a single string (defensive)
+        else if (key.endsWith('Ids') && typeof value === 'string' && idMap.has(value)) {
+          remapped[key] = idMap.get(value)
+        }
+        // GlossItem content carrying a referenced ID
+        else if (key === 'content' && typeof value === 'string' && (isObjectRef || isInstanceTypeRef) && idMap.has(value)) {
+          remapped[key] = idMap.get(value)
+        }
+        // Recurse into nested objects and arrays
         else if (typeof value === 'object' && value !== null) {
           remapped[key] = this.remapObjectIds(value, idMap)
         }
@@ -1052,6 +1074,109 @@ export class ImportHandler {
    * @param options - Import options
    * @returns Import result
    */
+  /**
+   * Detect whether the import contains data from a different user.
+   *
+   * Priority order:
+   *   1. Provenance `metadata` line with `exporterUserId` (definitive,
+   *      present on exports from this version onward).
+   *   2. Any `persona` line whose `userId` differs from the importer
+   *      (legacy fallback for older exports).
+   *   3. Any annotation carrying a `userId` that differs (covers exports
+   *      containing only object annotations with no persona).
+   *
+   * Returning `true` forces regeneration of every ID in the batch. When
+   * the batch has no persona lines AND no metadata AND no userId-bearing
+   * annotations (i.e. a legacy export), we return `false` to preserve
+   * the existing same-user re-import UX.
+   */
+  isCrossUserImport(lines: ImportLine[]): boolean {
+    for (const line of lines) {
+      if (line.type === 'metadata') {
+        const exporterUserId = (line.data as { exporterUserId?: unknown }).exporterUserId
+        if (typeof exporterUserId === 'string' && exporterUserId.length > 0) {
+          return exporterUserId !== this.userId
+        }
+      }
+    }
+    for (const line of lines) {
+      if (line.type === 'persona' && typeof line.data.userId === 'string') {
+        if (line.data.userId !== this.userId) return true
+      }
+    }
+    for (const line of lines) {
+      if (line.type === 'annotation') {
+        const annUserId = (line.data as { userId?: unknown }).userId
+        if (typeof annUserId === 'string' && annUserId !== this.userId) return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Generate create-new resolutions for all items that don't already have
+   * a conflict resolution. Used for cross-user imports where ALL IDs must
+   * be regenerated regardless of whether they collide with existing data.
+   */
+  generateCrossUserResolutions(lines: ImportLine[], existingResolutions: Resolution[]): Resolution[] {
+    // Only treat items with an existing create-new resolution as already resolved.
+    // Skip/replace/merge resolutions from non-ID conflicts (e.g. missing-dependency)
+    // must not block ID regeneration for cross-user imports.
+    const resolvedIds = new Set(
+      existingResolutions.filter(r => r.action === 'create-new').map(r => r.originalId)
+    )
+    const additionalResolutions: Resolution[] = []
+
+    for (const line of lines) {
+      const id = line.data.id as string | undefined
+      if (!id || resolvedIds.has(id)) continue
+
+      let conflictType: Resolution['conflictType']
+      switch (line.type) {
+        case 'persona':
+          conflictType = 'duplicate-persona'
+          break
+        case 'annotation':
+          conflictType = 'duplicate-sequence'
+          break
+        case 'entity':
+        case 'event':
+        case 'time':
+        case 'entity_collection':
+        case 'entityCollection':
+        case 'event_collection':
+        case 'eventCollection':
+        case 'time_collection':
+        case 'timeCollection':
+        case 'relation':
+          conflictType = 'duplicate-object'
+          break
+        case 'summary':
+          conflictType = 'duplicate-summary'
+          break
+        case 'claim':
+          conflictType = 'duplicate-claim'
+          break
+        case 'claim_relation':
+          conflictType = 'duplicate-claim-relation'
+          break
+        default:
+          continue
+      }
+
+      additionalResolutions.push({
+        conflictType,
+        strategy: 'create-new',
+        originalId: id,
+        newId: randomUUID(),
+        action: 'create-new'
+      })
+      resolvedIds.add(id)
+    }
+
+    return additionalResolutions
+  }
+
   async executeImport(lines: ImportLine[], options: ImportOptions): Promise<ImportResult> {
     const result: ImportResult = {
       success: false,
@@ -1096,6 +1221,13 @@ export class ImportHandler {
     // Detect conflicts
     const conflicts = await this.detectConflicts(lines, existingData)
     const resolutions = this.resolveConflicts(conflicts, options)
+
+    // For cross-user imports, regenerate ALL IDs (not just conflicting ones)
+    const crossUser = this.isCrossUserImport(lines)
+    if (crossUser) {
+      const additionalResolutions = this.generateCrossUserResolutions(lines, resolutions)
+      resolutions.push(...additionalResolutions)
+    }
 
     // Check for fail actions
     const failResolutions = resolutions.filter(r => r.action === 'fail')

--- a/server/test/services/import-cross-user.test.ts
+++ b/server/test/services/import-cross-user.test.ts
@@ -775,4 +775,889 @@ describe('Cross-user import ownership', () => {
       expect(parsed.data.id).toBe('persona-1')
     })
   })
+
+  describe('isCrossUserImport - metadata-driven detection', () => {
+    it('should detect cross-user via metadata line with a foreign exporterUserId', () => {
+      const lines: ImportLine[] = [
+        { type: 'metadata', data: { exporterUserId: USER_A, exportVersion: '1.0' }, lineNumber: 1 },
+        // No persona lines - only world data and object annotations
+        { type: 'entity', data: { id: 'ent-1', name: 'X' }, lineNumber: 2 },
+        createAnnotationLine('ann-1', 'p-unused', 'vid-1', 3),
+      ]
+
+      expect(handlerB.isCrossUserImport(lines)).toBe(true)
+    })
+
+    it('should treat same exporterUserId metadata as same-user', () => {
+      const lines: ImportLine[] = [
+        { type: 'metadata', data: { exporterUserId: USER_A, exportVersion: '1.0' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'X' }, lineNumber: 2 },
+      ]
+
+      expect(handlerA.isCrossUserImport(lines)).toBe(false)
+    })
+
+    it('should prefer metadata over persona signal when both are present', () => {
+      // Metadata says USER_A; persona line claims USER_B — metadata wins.
+      const lines: ImportLine[] = [
+        { type: 'metadata', data: { exporterUserId: USER_A, exportVersion: '1.0' }, lineNumber: 1 },
+        { type: 'persona', data: { id: 'p-1', userId: USER_B, name: 'B' }, lineNumber: 2 },
+      ]
+
+      expect(handlerA.isCrossUserImport(lines)).toBe(false)
+      expect(handlerB.isCrossUserImport(lines)).toBe(true)
+    })
+
+    it('should detect cross-user via annotation userId when no persona or metadata', () => {
+      // Legacy export that emitted userId on object annotations but no metadata line.
+      const lines: ImportLine[] = [
+        { type: 'entity', data: { id: 'ent-1', name: 'X' }, lineNumber: 1 },
+        {
+          type: 'annotation',
+          data: {
+            id: 'ann-1',
+            videoId: 'vid-1',
+            userId: USER_A,
+            annotationType: 'object',
+            linkedEntityId: 'ent-1',
+            boundingBoxSequence: {
+              boxes: [{ x: 0, y: 0, width: 10, height: 10, frameNumber: 0, isKeyframe: true }],
+              interpolationSegments: [],
+              visibilityRanges: [{ startFrame: 0, endFrame: 0, visible: true }],
+              totalFrames: 1, keyframeCount: 1, interpolatedFrameCount: 0,
+            },
+          },
+          lineNumber: 2,
+        },
+      ]
+
+      expect(handlerB.isCrossUserImport(lines)).toBe(true)
+    })
+
+    it('should ignore metadata with empty/missing exporterUserId', () => {
+      const lines: ImportLine[] = [
+        { type: 'metadata', data: { exportVersion: '1.0' }, lineNumber: 1 },
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A' }, lineNumber: 2 },
+      ]
+
+      // Empty metadata falls through to persona detection.
+      expect(handlerB.isCrossUserImport(lines)).toBe(true)
+      expect(handlerA.isCrossUserImport(lines)).toBe(false)
+    })
+
+    it('regenerates ALL IDs for a no-persona export with only world objects + annotations', async () => {
+      // The catastrophic case: a user labels videos with object annotations
+      // linking to world entities, never creates a persona, exports, and
+      // another user imports. All IDs must be regenerated.
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'metadata', data: { exporterUserId: USER_A, exportVersion: '1.0' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'Thing' }, lineNumber: 2 },
+        {
+          type: 'annotation',
+          data: {
+            id: 'ann-1',
+            videoId: 'vid-1',
+            userId: USER_A,
+            annotationType: 'object',
+            linkedEntityId: 'ent-1',
+            boundingBoxSequence: {
+              boxes: [{ x: 0, y: 0, width: 10, height: 10, frameNumber: 0, isKeyframe: true }],
+              interpolationSegments: [],
+              visibilityRanges: [{ startFrame: 0, endFrame: 0, visible: true }],
+              totalFrames: 1, keyframeCount: 1, interpolatedFrameCount: 0,
+            },
+          },
+          lineNumber: 3,
+        },
+      ]
+
+      expect(handlerB.isCrossUserImport(exportedLines)).toBe(true)
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newEntId = remapped[1].data.id as string
+      const newAnnId = remapped[2].data.id as string
+      expect(newEntId).not.toBe('ent-1')
+      expect(newAnnId).not.toBe('ann-1')
+      // linkedEntityId follows the regenerated entity
+      expect(remapped[2].data.linkedEntityId).toBe(newEntId)
+    })
+  })
+
+  describe('export emits metadata with exporterUserId', () => {
+    it('should prepend a metadata line to exportAll output', async () => {
+      // Construct a Prisma stub just for exportAll's dependencies.
+      const exporter = new AnnotationExporter()
+      const prismaStub = {
+        persona: { findMany: vi.fn().mockResolvedValue([]) },
+        ontology: { findMany: vi.fn().mockResolvedValue([]) },
+        worldState: { findUnique: vi.fn().mockResolvedValue(null) },
+        videoSummary: { findMany: vi.fn().mockResolvedValue([]) },
+        claim: { findMany: vi.fn().mockResolvedValue([]) },
+        claimRelation: { findMany: vi.fn().mockResolvedValue([]) },
+        annotation: { findMany: vi.fn().mockResolvedValue([]) },
+      } as unknown as PrismaClient
+
+      const out = await exporter.exportAll(prismaStub, USER_A)
+      const firstLine = out.split('\n')[0]
+      const parsed = JSON.parse(firstLine)
+
+      expect(parsed.type).toBe('metadata')
+      expect(parsed.data.exporterUserId).toBe(USER_A)
+      expect(typeof parsed.data.exportedAt).toBe('string')
+      expect(parsed.data.exportVersion).toBe('1.0')
+    })
+  })
+
+  describe('isCrossUserImport - detection logic', () => {
+    it('should detect cross-user import when persona userId differs', () => {
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A' }, lineNumber: 1 },
+      ]
+
+      expect(handlerB.isCrossUserImport(lines)).toBe(true)
+    })
+
+    it('should NOT detect cross-user import for same user', () => {
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A' }, lineNumber: 1 },
+      ]
+
+      expect(handlerA.isCrossUserImport(lines)).toBe(false)
+    })
+
+    it('should NOT detect cross-user import when persona has no userId', () => {
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', name: 'A' }, lineNumber: 1 },
+      ]
+
+      expect(handlerB.isCrossUserImport(lines)).toBe(false)
+    })
+
+    it('should detect cross-user import when ANY persona has different userId', () => {
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_B, name: 'B' }, lineNumber: 1 },
+        { type: 'persona', data: { id: 'p-2', userId: USER_A, name: 'A' }, lineNumber: 2 },
+      ]
+
+      // From User B's perspective, the second persona is foreign
+      expect(handlerB.isCrossUserImport(lines)).toBe(true)
+    })
+
+    it('should ignore non-persona lines for cross-user detection', () => {
+      const lines: ImportLine[] = [
+        createAnnotationLine('ann-1', 'persona-1', 'vid-1', 1),
+        { type: 'entity', data: { id: 'ent-1', name: 'Thing' }, lineNumber: 2 },
+      ]
+
+      // No persona lines at all - cannot detect cross-user
+      expect(handlerB.isCrossUserImport(lines)).toBe(false)
+    })
+  })
+
+  describe('generateCrossUserResolutions - new IDs for all foreign items', () => {
+    it('should generate create-new resolutions for items without existing resolutions', () => {
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'Person' }, lineNumber: 2 },
+        createAnnotationLine('ann-1', 'p-1', 'vid-1', 3),
+        { type: 'summary', data: { id: 'sum-1', videoId: 'vid-1', personaId: 'p-1' }, lineNumber: 4 },
+        { type: 'claim', data: { id: 'claim-1', summaryId: 'sum-1', text: 'x' }, lineNumber: 5 },
+        { type: 'claim_relation', data: { id: 'cr-1', sourceClaimId: 'claim-1', targetClaimId: 'claim-1' }, lineNumber: 6 },
+      ]
+
+      const existingResolutions: Resolution[] = []
+      const additional = handlerB.generateCrossUserResolutions(lines, existingResolutions)
+
+      expect(additional).toHaveLength(6)
+      for (const res of additional) {
+        expect(res.action).toBe('create-new')
+        expect(res.newId).toBeDefined()
+        expect(res.newId).not.toBe(res.originalId)
+      }
+
+      const resolvedOriginalIds = additional.map(r => r.originalId)
+      expect(resolvedOriginalIds).toContain('p-1')
+      expect(resolvedOriginalIds).toContain('ent-1')
+      expect(resolvedOriginalIds).toContain('ann-1')
+      expect(resolvedOriginalIds).toContain('sum-1')
+      expect(resolvedOriginalIds).toContain('claim-1')
+      expect(resolvedOriginalIds).toContain('cr-1')
+    })
+
+    it('should skip items that already have resolutions', () => {
+      const lines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A' }, lineNumber: 1 },
+        createAnnotationLine('ann-1', 'p-1', 'vid-1', 2),
+      ]
+
+      // p-1 already has a resolution from conflict detection
+      const existingResolutions: Resolution[] = [{
+        conflictType: 'duplicate-persona',
+        strategy: 'create-new',
+        originalId: 'p-1',
+        newId: 'p-1-already-resolved',
+        action: 'create-new',
+      }]
+
+      const additional = handlerB.generateCrossUserResolutions(lines, existingResolutions)
+
+      // Only ann-1 should get a new resolution, p-1 already has one
+      expect(additional).toHaveLength(1)
+      expect(additional[0].originalId).toBe('ann-1')
+    })
+
+    it('should not generate resolutions for metadata or video lines', () => {
+      const lines: ImportLine[] = [
+        { type: 'metadata', data: { version: '1.0' }, lineNumber: 1 },
+        { type: 'video', data: { id: 'vid-1' }, lineNumber: 2 },
+      ]
+
+      const additional = handlerB.generateCrossUserResolutions(lines, [])
+
+      // metadata has no id, video type is skipped in the switch
+      expect(additional).toHaveLength(0)
+    })
+
+    it('should handle collection types correctly', () => {
+      const lines: ImportLine[] = [
+        { type: 'entity_collection', data: { id: 'ec-1' }, lineNumber: 1 },
+        { type: 'event_collection', data: { id: 'evc-1' }, lineNumber: 2 },
+        { type: 'time_collection', data: { id: 'tc-1' }, lineNumber: 3 },
+        { type: 'entityCollection', data: { id: 'ec-2' }, lineNumber: 4 },
+        { type: 'eventCollection', data: { id: 'evc-2' }, lineNumber: 5 },
+        { type: 'timeCollection', data: { id: 'tc-2' }, lineNumber: 6 },
+        { type: 'relation', data: { id: 'rel-1' }, lineNumber: 7 },
+      ]
+
+      const additional = handlerB.generateCrossUserResolutions(lines, [])
+
+      expect(additional).toHaveLength(7)
+      for (const res of additional) {
+        expect(res.action).toBe('create-new')
+        expect(res.newId).toBeDefined()
+      }
+    })
+
+    it('should not duplicate IDs when same ID appears in multiple lines', () => {
+      const lines: ImportLine[] = [
+        { type: 'entity', data: { id: 'ent-1', name: 'Person' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'Person duplicate' }, lineNumber: 2 },
+      ]
+
+      const additional = handlerB.generateCrossUserResolutions(lines, [])
+
+      // Should only generate one resolution for ent-1
+      expect(additional).toHaveLength(1)
+      expect(additional[0].originalId).toBe('ent-1')
+    })
+  })
+
+  describe('end-to-end: cross-user import with NO pre-existing data (the critical bug)', () => {
+    it('should regenerate ALL IDs when importing foreign data into empty database', async () => {
+      // User B has NO data - completely fresh account
+      const emptyExistingData = createEmptyExistingData()
+
+      // User A's exported data
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'persona-a', userId: USER_A, name: 'Analyst', role: 'Analyst', informationNeed: 'Testing' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'Person' }, lineNumber: 2 },
+        { type: 'event', data: { id: 'evt-1', name: 'Meeting' }, lineNumber: 3 },
+        { type: 'time', data: { id: 'time-1', name: 'Monday' }, lineNumber: 4 },
+        { type: 'summary', data: { id: 'sum-1', videoId: 'vid-1', personaId: 'persona-a' }, lineNumber: 5 },
+        { type: 'claim', data: { id: 'claim-1', summaryId: 'sum-1', text: 'A claim' }, lineNumber: 6 },
+        { type: 'claim_relation', data: { id: 'cr-1', sourceClaimId: 'claim-1', targetClaimId: 'claim-1', relationTypeId: 'rt-1' }, lineNumber: 7 },
+        createAnnotationLine('ann-1', 'persona-a', 'vid-1', 8),
+      ]
+
+      // Step 1: No conflicts because database is empty
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      // detectConflicts synthesizes "foreign data" conflicts for each cross-user
+      // line even when the DB is empty, so resolveConflicts can issue create-new
+      // resolutions. Every non-missing conflict here must be tagged foreign.
+      const duplicateConflicts = conflicts.filter(c => !c.type.startsWith('missing'))
+      for (const c of duplicateConflicts) {
+        expect(c.ownedByImporter).toBe(false)
+      }
+
+      // Step 2: Resolve (empty - no conflicts)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+
+      // Step 3: This is the critical fix - cross-user detection
+      expect(handlerB.isCrossUserImport(exportedLines)).toBe(true)
+      const additionalResolutions = handlerB.generateCrossUserResolutions(exportedLines, resolutions)
+      resolutions.push(...additionalResolutions)
+
+      // All items with IDs should have create-new resolutions
+      const createNewResolutions = resolutions.filter(r => r.action === 'create-new')
+      expect(createNewResolutions.length).toBeGreaterThanOrEqual(8)
+
+      // Step 4: Remap IDs
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      // ALL IDs should be different from originals
+      expect(remapped[0].data.id).not.toBe('persona-a')
+      expect(remapped[1].data.id).not.toBe('ent-1')
+      expect(remapped[2].data.id).not.toBe('evt-1')
+      expect(remapped[3].data.id).not.toBe('time-1')
+      expect(remapped[4].data.id).not.toBe('sum-1')
+      expect(remapped[5].data.id).not.toBe('claim-1')
+      expect(remapped[6].data.id).not.toBe('cr-1')
+      expect(remapped[7].data.id).not.toBe('ann-1')
+
+      // All IDs should be valid UUIDs (36 chars with dashes)
+      for (const line of remapped) {
+        if (line.data.id && line.type !== 'metadata') {
+          expect(line.data.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+        }
+      }
+
+      // References should be updated consistently
+      const newPersonaId = remapped[0].data.id
+      const newSummaryId = remapped[4].data.id
+      const newClaimId = remapped[5].data.id
+
+      // Summary should reference new persona
+      expect(remapped[4].data.personaId).toBe(newPersonaId)
+      // Claim should reference new summary
+      expect(remapped[5].data.summaryId).toBe(newSummaryId)
+      // Claim relation should reference new claims
+      expect(remapped[6].data.sourceClaimId).toBe(newClaimId)
+      expect(remapped[6].data.targetClaimId).toBe(newClaimId)
+      // Annotation should reference new persona
+      expect(remapped[7].data.personaId).toBe(newPersonaId)
+    })
+
+    it('should preserve IDs when same user re-imports into empty database', async () => {
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'persona-a', userId: USER_A, name: 'Analyst', role: 'Analyst', informationNeed: 'Testing' }, lineNumber: 1 },
+        createAnnotationLine('ann-1', 'persona-a', 'vid-1', 2),
+      ]
+
+      const conflicts = await handlerA.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerA.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+
+      // Same user - should NOT be cross-user
+      expect(handlerA.isCrossUserImport(exportedLines)).toBe(false)
+
+      // No additional resolutions needed
+      const remapped = handlerA.remapIds(exportedLines, resolutions)
+
+      // IDs should be preserved
+      expect(remapped[0].data.id).toBe('persona-a')
+      expect(remapped[1].data.id).toBe('ann-1')
+    })
+
+    it('should regenerate IDs for cross-user import with PARTIAL overlap', async () => {
+      // Some of User A's data already exists (from a prior import attempt)
+      const existingData = createEmptyExistingData()
+      existingData.personaIds.add('persona-a')
+      // NOT owned by User B
+      existingData.annotationIds.add('ann-1')
+      // NOT owned by User B
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'persona-a', userId: USER_A, name: 'Analyst', role: 'Analyst', informationNeed: 'Testing' }, lineNumber: 1 },
+        { type: 'summary', data: { id: 'sum-1', videoId: 'vid-1', personaId: 'persona-a' }, lineNumber: 2 },
+        createAnnotationLine('ann-1', 'persona-a', 'vid-1', 3),
+        createAnnotationLine('ann-2', 'persona-a', 'vid-1', 4),
+      ]
+
+      // Detect conflicts - only persona-a and ann-1 conflict
+      const conflicts = await handlerB.detectConflicts(exportedLines, existingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+
+      // Cross-user detection adds resolutions for sum-1 and ann-2
+      const additionalResolutions = handlerB.generateCrossUserResolutions(exportedLines, resolutions)
+      resolutions.push(...additionalResolutions)
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      // ALL IDs should be regenerated - both conflicting and non-conflicting
+      expect(remapped[0].data.id).not.toBe('persona-a')
+      expect(remapped[1].data.id).not.toBe('sum-1')
+      expect(remapped[2].data.id).not.toBe('ann-1')
+      expect(remapped[3].data.id).not.toBe('ann-2')
+
+      // References should be consistent
+      const newPersonaId = remapped[0].data.id
+      expect(remapped[1].data.personaId).toBe(newPersonaId)
+      expect(remapped[2].data.personaId).toBe(newPersonaId)
+      expect(remapped[3].data.personaId).toBe(newPersonaId)
+    })
+
+    it('should regenerate IDs for ontology lines linked to foreign personas', async () => {
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'persona-a', userId: USER_A, name: 'Analyst', role: 'Analyst', informationNeed: 'Testing' }, lineNumber: 1 },
+        { type: 'ontology', data: { personaId: 'persona-a', entityTypes: [], eventTypes: [] }, lineNumber: 2 },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      const additionalResolutions = handlerB.generateCrossUserResolutions(exportedLines, resolutions)
+      resolutions.push(...additionalResolutions)
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      // Persona ID regenerated
+      expect(remapped[0].data.id).not.toBe('persona-a')
+      // Ontology's personaId reference updated
+      expect(remapped[1].data.personaId).toBe(remapped[0].data.id)
+    })
+
+    it('should regenerate entity/event/time references in annotations', async () => {
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'Person' }, lineNumber: 2 },
+        { type: 'event', data: { id: 'evt-1', name: 'Walk' }, lineNumber: 3 },
+        { type: 'time', data: { id: 'time-1' }, lineNumber: 4 },
+        {
+          type: 'annotation',
+          data: {
+            id: 'ann-obj-1',
+            videoId: 'vid-1',
+            annotationType: 'object',
+            linkedEntityId: 'ent-1',
+            linkedEventId: 'evt-1',
+            linkedTimeId: 'time-1',
+            boundingBoxSequence: {
+              boxes: [{ x: 0, y: 0, width: 50, height: 50, frameNumber: 0, isKeyframe: true }],
+              interpolationSegments: [],
+              visibilityRanges: [{ startFrame: 0, endFrame: 0, visible: true }],
+              totalFrames: 1, keyframeCount: 1, interpolatedFrameCount: 0
+            }
+          },
+          lineNumber: 5,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      const additionalResolutions = handlerB.generateCrossUserResolutions(exportedLines, resolutions)
+      resolutions.push(...additionalResolutions)
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newEntId = remapped[1].data.id
+      const newEvtId = remapped[2].data.id
+      const newTimeId = remapped[3].data.id
+
+      expect(remapped[4].data.linkedEntityId).toBe(newEntId)
+      expect(remapped[4].data.linkedEventId).toBe(newEvtId)
+      expect(remapped[4].data.linkedTimeId).toBe(newTimeId)
+    })
+
+    it('should preserve typeRef cross-references in claim gloss (fovea-export-5 structure)', async () => {
+      // Mirrors fovea-export-5.jsonl: claim gloss contains a typeRef whose
+      // content points to an entity type nested inside an ontology line.
+      // The entity type ID is NOT a top-level line ID so it is preserved,
+      // and the typeRef.content (same ID) must stay consistent with it.
+      const emptyExistingData = createEmptyExistingData()
+
+      const PERSONA_ID = '57175232-62f7-4af2-96b4-bd8fd361adab'
+      const ENTITY_TYPE_ID = '5ae47153-7b93-4a5c-8a39-4ee5ff833c40'
+      const SUMMARY_ID = '159c2b9e-e759-45ec-a0cd-457a9ad7c86b'
+      const CLAIM_ID = 'f7fb6250-c36e-4507-9a34-aa097c90f558'
+      const ENTITY_ID = '0bfcd227-c571-4608-8c81-bc1e05bcd7a2'
+      const ANN_ID = '56a94afd-0e98-42b5-9a19-5a35cdd19cb4'
+
+      const exportedLines: ImportLine[] = [
+        {
+          type: 'persona',
+          data: { id: PERSONA_ID, userId: USER_A, name: 'Test Analyst', role: 'Test Analyst', informationNeed: 'x' },
+          lineNumber: 1,
+        },
+        {
+          type: 'ontology',
+          data: {
+            personaId: PERSONA_ID,
+            entityTypes: [{ id: ENTITY_TYPE_ID, name: 'fire' }],
+            eventTypes: [],
+            roleTypes: [],
+            relationTypes: [],
+            relations: [],
+          },
+          lineNumber: 2,
+        },
+        { type: 'entity', data: { id: ENTITY_ID, name: 'Fred Rogers' }, lineNumber: 3 },
+        {
+          type: 'summary',
+          data: { id: SUMMARY_ID, videoId: 'vid-1', personaId: PERSONA_ID, summary: [], keyFrames: [] },
+          lineNumber: 4,
+        },
+        {
+          type: 'claim',
+          data: {
+            id: CLAIM_ID,
+            summaryId: SUMMARY_ID,
+            summaryType: 'video',
+            text: 'claim about type',
+            gloss: [
+              { type: 'text', content: 'claim about ' },
+              { type: 'typeRef', content: ENTITY_TYPE_ID, refType: 'entity', refPersonaId: PERSONA_ID },
+            ],
+          },
+          lineNumber: 5,
+        },
+        {
+          type: 'annotation',
+          data: {
+            id: ANN_ID,
+            videoId: 'vid-1',
+            annotationType: 'object',
+            linkedEntityId: ENTITY_ID,
+            boundingBoxSequence: {
+              boxes: [{ x: 0, y: 0, width: 10, height: 10, frameNumber: 0, isKeyframe: true }],
+              interpolationSegments: [],
+              visibilityRanges: [{ startFrame: 0, endFrame: 0, visible: true }],
+              totalFrames: 1, keyframeCount: 1, interpolatedFrameCount: 0,
+            },
+          },
+          lineNumber: 6,
+        },
+      ]
+
+      expect(handlerB.isCrossUserImport(exportedLines)).toBe(true)
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newPersonaId = remapped[0].data.id as string
+      const newEntityId = remapped[2].data.id as string
+      const newSummaryId = remapped[3].data.id as string
+
+      // Top-level IDs regenerated
+      expect(newPersonaId).not.toBe(PERSONA_ID)
+      expect(newEntityId).not.toBe(ENTITY_ID)
+      expect(newSummaryId).not.toBe(SUMMARY_ID)
+      expect(remapped[4].data.id).not.toBe(CLAIM_ID)
+      expect(remapped[5].data.id).not.toBe(ANN_ID)
+
+      // Ontology's personaId updated to new persona
+      expect(remapped[1].data.personaId).toBe(newPersonaId)
+
+      // Nested entity-type ID inside ontology is PRESERVED (not a top-level line ID)
+      const entityTypes = (remapped[1].data as { entityTypes: Array<{ id: string }> }).entityTypes
+      expect(entityTypes[0].id).toBe(ENTITY_TYPE_ID)
+
+      // Summary/claim references updated
+      expect(remapped[3].data.personaId).toBe(newPersonaId)
+      expect(remapped[4].data.summaryId).toBe(newSummaryId)
+
+      // Claim gloss: typeRef.refPersonaId remapped to new persona;
+      // typeRef.content (the entity-type ID) preserved to stay in sync with ontology
+      const gloss = (remapped[4].data as { gloss: Array<{ type: string; content: string; refPersonaId?: string }> }).gloss
+      const typeRef = gloss.find(g => g.type === 'typeRef')!
+      expect(typeRef.content).toBe(ENTITY_TYPE_ID)
+      expect(typeRef.refPersonaId).toBe(newPersonaId)
+
+      // Annotation's linkedEntityId follows the regenerated entity
+      expect(remapped[5].data.linkedEntityId).toBe(newEntityId)
+    })
+
+    it('should remap string array reference fields like entityIds on collections', async () => {
+      // EntityCollection.entityIds is a string[] — the generic remapper
+      // must walk array elements, not only remap scalar *Id fields.
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'A' }, lineNumber: 2 },
+        { type: 'entity', data: { id: 'ent-2', name: 'B' }, lineNumber: 3 },
+        {
+          type: 'entity_collection',
+          data: { id: 'ec-1', name: 'pair', entityIds: ['ent-1', 'ent-2'], collectionType: 'group' },
+          lineNumber: 4,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newEnt1 = remapped[1].data.id as string
+      const newEnt2 = remapped[2].data.id as string
+      const newEntityIds = (remapped[3].data as { entityIds: string[] }).entityIds
+
+      expect(newEnt1).not.toBe('ent-1')
+      expect(newEnt2).not.toBe('ent-2')
+      expect(newEntityIds).toEqual([newEnt1, newEnt2])
+    })
+
+    it('should remap eventIds string array on event collections', async () => {
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        { type: 'event', data: { id: 'evt-1', name: 'A' }, lineNumber: 2 },
+        { type: 'event', data: { id: 'evt-2', name: 'B' }, lineNumber: 3 },
+        {
+          type: 'event_collection',
+          data: { id: 'evc-1', name: 'seq', eventIds: ['evt-1', 'evt-2'], collectionType: 'sequence' },
+          lineNumber: 4,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newEvt1 = remapped[1].data.id as string
+      const newEvt2 = remapped[2].data.id as string
+      const newEventIds = (remapped[3].data as { eventIds: string[] }).eventIds
+
+      expect(newEventIds).toEqual([newEvt1, newEvt2])
+    })
+
+    it('should remap GlossItem content when the ref points to a regenerated object', async () => {
+      // objectRef/annotationRef/claimRef GlossItems store an ID in `content`
+      // (not a *Id-suffixed key). For cross-user imports these IDs must still
+      // be rewritten or claims/annotations will reference foreign originals.
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'Person' }, lineNumber: 2 },
+        { type: 'summary', data: { id: 'sum-1', videoId: 'vid-1', personaId: 'p-1' }, lineNumber: 3 },
+        {
+          type: 'claim',
+          data: {
+            id: 'claim-1',
+            summaryId: 'sum-1',
+            summaryType: 'video',
+            text: 'about a person',
+            gloss: [
+              { type: 'text', content: 'about ' },
+              { type: 'objectRef', content: 'ent-1', refType: 'entity-object' },
+            ],
+          },
+          lineNumber: 4,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newEntId = remapped[1].data.id as string
+      const gloss = (remapped[3].data as { gloss: Array<{ type: string; content: string }> }).gloss
+      const objectRef = gloss.find(g => g.type === 'objectRef')!
+
+      expect(newEntId).not.toBe('ent-1')
+      expect(objectRef.content).toBe(newEntId)
+    })
+
+    it('should remap GlossItem annotationRef content pointing to a regenerated annotation', async () => {
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        createAnnotationLine('ann-1', 'p-1', 'vid-1', 2),
+        { type: 'summary', data: { id: 'sum-1', videoId: 'vid-1', personaId: 'p-1' }, lineNumber: 3 },
+        {
+          type: 'claim',
+          data: {
+            id: 'claim-1',
+            summaryId: 'sum-1',
+            summaryType: 'video',
+            text: 'cf annotation',
+            gloss: [
+              { type: 'annotationRef', content: 'ann-1', refType: 'annotation' },
+            ],
+          },
+          lineNumber: 4,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newAnnId = remapped[1].data.id as string
+      const gloss = (remapped[3].data as { gloss: Array<{ type: string; content: string }> }).gloss
+      const annRef = gloss.find(g => g.type === 'annotationRef')!
+
+      expect(annRef.content).toBe(newAnnId)
+    })
+
+    it('should leave typeRef content pointing to ontology types unchanged', async () => {
+      // Entity/role/event/relation TYPES are nested inside ontology lines
+      // (no top-level line ID), so they are preserved across cross-user
+      // imports and their typeRef.content must stay unchanged.
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        {
+          type: 'ontology',
+          data: {
+            personaId: 'p-1',
+            entityTypes: [{ id: 'etype-1', name: 'fire' }],
+            eventTypes: [], roleTypes: [], relationTypes: [], relations: [],
+          },
+          lineNumber: 2,
+        },
+        { type: 'summary', data: { id: 'sum-1', videoId: 'vid-1', personaId: 'p-1' }, lineNumber: 3 },
+        {
+          type: 'claim',
+          data: {
+            id: 'claim-1',
+            summaryId: 'sum-1',
+            gloss: [{ type: 'typeRef', content: 'etype-1', refType: 'entity', refPersonaId: 'p-1' }],
+          },
+          lineNumber: 4,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const gloss = (remapped[3].data as { gloss: Array<{ type: string; content: string; refPersonaId?: string }> }).gloss
+      const typeRef = gloss[0]
+
+      expect(typeRef.content).toBe('etype-1')
+      expect(typeRef.refPersonaId).toBe(remapped[0].data.id)
+    })
+
+    it('should remap typeAssignments arrays with nested personaId refs', async () => {
+      // Entities and events carry typeAssignments: [{ personaId, entityTypeId }].
+      // personaId must follow the regenerated persona; entityTypeId stays
+      // unchanged (it points to a nested ontology type).
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        {
+          type: 'entity',
+          data: {
+            id: 'ent-1',
+            name: 'X',
+            typeAssignments: [{ personaId: 'p-1', entityTypeId: 'etype-nested', confidence: 0.9 }],
+          },
+          lineNumber: 2,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      const newPersonaId = remapped[0].data.id as string
+      const assignments = (remapped[1].data as { typeAssignments: Array<{ personaId: string; entityTypeId: string }> }).typeAssignments
+
+      expect(assignments[0].personaId).toBe(newPersonaId)
+      expect(assignments[0].entityTypeId).toBe('etype-nested')
+    })
+
+    it('should not detect cross-user when persona userId is null or undefined', () => {
+      // Legacy exports may not carry userId; we should not incorrectly flag them.
+      const withNull: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: null, name: 'A' }, lineNumber: 1 },
+      ]
+      const withUndef: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', name: 'A' }, lineNumber: 1 },
+      ]
+
+      expect(handlerB.isCrossUserImport(withNull)).toBe(false)
+      expect(handlerB.isCrossUserImport(withUndef)).toBe(false)
+    })
+
+    it('should prefer create-new over a skip resolution when both exist for same originalId', async () => {
+      // Regression: missing-dependency conflicts resolve to skip and were
+      // previously blocking cross-user ID regeneration for annotations
+      // referencing not-yet-imported entities.
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-1', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        { type: 'entity', data: { id: 'ent-1', name: 'E' }, lineNumber: 2 },
+        {
+          type: 'annotation',
+          data: {
+            id: 'ann-1',
+            videoId: 'vid-1',
+            personaId: 'p-1',
+            annotationType: 'object',
+            linkedEntityId: 'ent-1',
+            boundingBoxSequence: {
+              boxes: [{ x: 0, y: 0, width: 10, height: 10, frameNumber: 0, isKeyframe: true }],
+              interpolationSegments: [],
+              visibilityRanges: [{ startFrame: 0, endFrame: 0, visible: true }],
+              totalFrames: 1, keyframeCount: 1, interpolatedFrameCount: 0,
+            },
+          },
+          lineNumber: 3,
+        },
+      ]
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      // Missing-dependency conflict is expected since ent-1 is not in DB yet.
+      expect(conflicts.some(c => c.type === 'missing-dependency')).toBe(true)
+
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      resolutions.push(...handlerB.generateCrossUserResolutions(exportedLines, resolutions))
+
+      // Two resolutions exist for ann-1 (skip from missing-dep, create-new from cross-user).
+      const annResolutions = resolutions.filter(r => r.originalId === 'ann-1')
+      expect(annResolutions.length).toBe(2)
+      expect(annResolutions.some(r => r.action === 'create-new')).toBe(true)
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+      // The annotation ID IS regenerated (create-new wins in idMap build).
+      expect(remapped[2].data.id).not.toBe('ann-1')
+      expect(remapped[2].data.linkedEntityId).toBe(remapped[1].data.id)
+    })
+
+    it('should handle multiple personas from different users', async () => {
+      const emptyExistingData = createEmptyExistingData()
+
+      const exportedLines: ImportLine[] = [
+        { type: 'persona', data: { id: 'p-a', userId: USER_A, name: 'A', role: 'A', informationNeed: 'A' }, lineNumber: 1 },
+        { type: 'persona', data: { id: 'p-b', userId: USER_B, name: 'B', role: 'B', informationNeed: 'B' }, lineNumber: 2 },
+        createAnnotationLine('ann-a', 'p-a', 'vid-1', 3),
+        createAnnotationLine('ann-b', 'p-b', 'vid-1', 4),
+      ]
+
+      // Import into User B's account - p-a is foreign, p-b is own
+      // But isCrossUserImport sees p-a as foreign, triggers full regen
+      expect(handlerB.isCrossUserImport(exportedLines)).toBe(true)
+
+      const conflicts = await handlerB.detectConflicts(exportedLines, emptyExistingData)
+      const resolutions = handlerB.resolveConflicts(conflicts, DEFAULT_IMPORT_OPTIONS)
+      const additionalResolutions = handlerB.generateCrossUserResolutions(exportedLines, resolutions)
+      resolutions.push(...additionalResolutions)
+
+      const remapped = handlerB.remapIds(exportedLines, resolutions)
+
+      // Both personas should get new IDs (conservative approach for consistency)
+      expect(remapped[0].data.id).not.toBe('p-a')
+      expect(remapped[1].data.id).not.toBe('p-b')
+
+      // Annotations should reference the new persona IDs
+      expect(remapped[2].data.personaId).toBe(remapped[0].data.id)
+      expect(remapped[3].data.personaId).toBe(remapped[1].data.id)
+    })
+  })
 })


### PR DESCRIPTION
## Description

Follow-up to #117 that closes three additional cross-user import gaps:

1. **No-persona exports** — #117 only detects cross-user imports when a `persona` line carries a foreign `userId`. Users who label videos with *object* annotations linked to world entities never create a persona, so their exports have no persona lines and foreign IDs leaked through unchanged.
2. **`*Ids` array fields** — `EntityCollection.entityIds` and `EventCollection.eventIds` are `string[]`, but `remapObjectIds` only rewrote scalar `*Id` strings. Array elements fell through unremapped, so collections pointed at the foreign user's world objects.
3. **`GlossItem` reference content** — `objectRef` / `annotationRef` / `claimRef` items (and `typeRef` with `refType: entity-object | event-object | time-object | location-object | annotation | claim`) carry the target ID in `content` — not a `*Id`-suffixed key — so remapping skipped them. Claims citing annotations or world objects ended up pointing at foreign IDs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

Relates to #100
Relates to #117

## Changes Made

- `export-handler.ts`: prepend a provenance `{type:"metadata", data:{exporterUserId, exportVersion, exportedAt}}` line to every full export; emit `userId` on exported object annotations.
- `import-handler.ts`:
  - New `isCrossUserImport()` method with three-tier detection (metadata → persona → annotation `userId`).
  - New `generateCrossUserResolutions()` that fills `create-new` resolutions for every line in a cross-user batch that isn't already resolved, overriding non-`create-new` resolutions (e.g. `missing-dependency` → `skip`) that previously blocked ID regeneration.
  - `remapObjectIds`: rewrite `*Ids` array elements; rewrite `GlossItem.content` when the item is an `objectRef` / `annotationRef` / `claimRef` or a `typeRef` with an instance-level `refType`.
- `ImportDataDialog.tsx`: cross-user banner, smart per-conflict defaults, "apply to all" bulk resolution, auto-collapse for large conflict groups.
- `export-import.ts` (model): extend the `Conflict` discriminated union with the new conflict types and the `ownedByImporter` flag.

## Testing

### Test Environment

- OS: macOS 15.6 (Darwin 24.6.0)
- Node: 20.x
- Browser: N/A for backend tests

### Test Cases

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] Manual testing completed
- [x] All existing tests pass

### How to Test

1. \`cd server && npx vitest run test/services/import-cross-user.test.ts\` — 59 tests pass (42 covering #117's behaviour, 17 new).
2. New tests specifically cover: no-persona exports, `*Ids` array remapping, `GlossItem` content remapping, metadata-driven detection, typeRef content preservation for nested ontology types, and the skip-vs-create-new resolution precedence regression.

## Screenshots

N/A — logic / data-integrity fix.

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: one extra JSONL line per full export; one extra `userId` field per object-annotation line.

## Breaking Changes

**Breaking changes:**
- None. Exports from this version gain a leading `metadata` line; older importers will see it as an unknown line type and ignore it (existing import code already treats unknown `type` values as inert).

**Migration guide:**
- None required.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Integration tests that require the live dev DB (\`database.test.ts\`, \`app.test.ts\`, \`export-scoping.test.ts\`) were not run in my environment because \`docker compose -f docker-compose.dev.yml up\` was not reachable. Those tests were already failing on \`main\` in the same environment for the same reason; no assertions tied to this change were skipped.

## Reviewer Guidance

The most important change to review is the priority ordering inside \`isCrossUserImport()\` and the scope-of-coverage argument in the new "no-persona + object-annotations" test. If you disagree with the fall-back-to-persona-then-annotation-userId ordering, say so — I chose metadata-first because the metadata line is the only signal we can fully trust going forward.