### PR TITLE
ci: run CI on PRs to release/** branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
 
 env:
   NODE_VERSION: '22'


### PR DESCRIPTION
## Description

Extends `ci.yml` to also trigger on `release/**` branch pushes and PRs. Currently `ci.yml` only fires for `[main, develop]`, so PRs targeting maintenance branches (`release/0.1.x` and any future `release/N.N.x`) only get the `link-check` workflow — backports merge with no automated lint or test signal. The v0.1.8 release (#123) hit this gap.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

Fixes #
Relates to # (release process surfaced in #123)

## Changes Made

- `.github/workflows/ci.yml` — `branches:` lists for both `push` and `pull_request` now include `'release/**'`. The same change was already cherry-picked onto `release/0.1.x` so v0.1.x maintenance PRs get CI immediately; this PR puts it on `main` so any future `release/0.2.x` etc. inherits.
- `deploy.yml`, `docker.yml`, `dev-build.yml`, `security.yml` are intentionally **not** changed — those workflows push to staging / publish images / scan production code and should remain `main`-gated. Backport PRs do not need them.

## Testing

### Test Environment

- N/A — workflow trigger config only.

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Open this PR — `ci.yml` runs on it (PR to `main` already in scope), so this very PR exercises the workflow.
2. After merge, opening any PR with base `release/**` will trigger `ci.yml` lint + test jobs.

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details:
Adds CI runtime to maintenance PRs (~5-10 min per PR). Negligible against the prevented-regression value.

## Breaking Changes

**Breaking changes:**
- None.

**Migration guide:**
- N/A.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The `release/0.1.x` branch already has this trigger (commit `a0238b5` on the maintenance branch) so PRs to that branch start running CI immediately. This PR puts the change on `main` so it forward-ports to whatever `release/0.2.x` we cut later.

## Reviewer Guidance

- The glob `release/**` matches `release/0.1.x`, `release/1.x`, `release/2.0.x`, etc.
- If a future workflow (e.g. an integration smoke that needs database credentials only available in `main`) needs `main`-only behavior, gate that workflow with `if: github.ref == 'refs/heads/main'` rather than removing `release/**` from this trigger.