### PR TITLE
fix: generalise cross-user import id remap (v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-05-13
+
+Forward-ports the v0.1.10 / v0.2.3 generalisation of the cross-user id remap to the v0.3.x line. The bug taxonomy and user-visible behaviour is the same; the integration is unchanged from v0.2.3 since `remapObjectIds` lives outside both the CASL surface introduced in v0.2.0 and the Clean Architecture refactor introduced in v0.3.0.
+
+### Changed
+
+- Replace the field-name allowlist inside `remapObjectIds` with a structure-agnostic substitution built from the cross-user `idMap` itself. The v0.3.2 fix added an inline-UUID regex pass as a fallback after the existing `id` / `*Id` / `*Ids` / gloss-`content` branches, but the allowlist still hid two correctness gaps: (1) `entityCollection.members` / `eventCollection.members` / `timeCollection.members` are id-reference arrays that the allowlist never matched (they do not end in `Ids`), so after a cross-user import every collection silently held pre-import ids pointing at entities that no longer existed in the importer's world; (2) any future id-bearing field whose name did not match the allowlist patterns would have the same problem. `remapIds` now lowercases `idMap` keys on insert, builds a single case-insensitive matcher from those keys sorted longest-first and RegExp-escaped, and applies it to every string value in the payload tree. Whole-string id values, ids embedded in surrounding prose, ids in arbitrary array positions (`members`, `entityIds`, ordinary string arrays), GlossItem `content`, and ids inside JSON-encoded substrings are all rewritten by the same pass; substrings whose lowercased form is not in `idMap` pass through unchanged, so the substitution is a strict no-op outside the cross-user path. Reported as a continuation of #121.
+
+### Added
+
+- Unit suite `test/services/import-handler-remap-ids.test.ts` (13 tests, no database) exercises every surface of the new id-shape substitution against a synthetic `idMap`: whole-string ids in arbitrary field names, inline mentions in `claim.text` / `claim.comment`, every free-text surface (persona `informationNeed` / `details`, ontology type descriptions, world object name / description, summary text, claim-relation description), nested structures through arrays and gloss `items`, `*Ids` arrays, collection `members` arrays, multiple ids in one string, ids embedded inside larger tokens (`claim_<id>_v2`, `entity-<id>.png`, `url=…/<id>?q=1`), uppercase / mixed-case ids, JSON-encoded blobs that carry ids, ids not in `idMap` left untouched, non-id strings unchanged, empty-resolutions no-op, and primitives (number / boolean / null) untouched. The integration comparator in `test/integration/import-export-fidelity.test.ts` now treats `members` as id-like so the round-trip diff stops asserting that reference arrays survive byte-for-byte; the round-trip behaviour itself is unchanged.
+
 ## [0.3.2] - 2026-05-11
 
 Forward-ports the v0.1.9 / v0.2.2 cross-user inline-UUID remap fix to the v0.3.x line. The bug taxonomy and user-visible behavior is the same; the integration is unchanged from v0.1.9 since `remapObjectIds` lives outside both the CASL surface and the Clean Architecture refactor of v0.3.0.

--- a/annotation-tool/package.json
+++ b/annotation-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fovea/annotation-tool",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fovea/server",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fovea/server",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.929.0",
         "@aws-sdk/s3-request-presigner": "^3.929.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fovea/server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/src/services/import-handler.ts
+++ b/server/src/services/import-handler.ts
@@ -92,26 +92,42 @@ interface CollectionData {
 }
 
 /**
- * Standard v4 / generic UUID pattern (8-4-4-4-12 hex), case-insensitive.
+ * Build a case-insensitive matcher whose alternations are the literal
+ * keys of `idMap`. The remap is structure-agnostic: rather than gate on
+ * field names (the previous remap walked an allowlist of `id` / `*Id` /
+ * `*Ids` / GlossItem `content`, which had to be extended every time the
+ * export schema gained a new id-bearing field and silently missed every
+ * free-form string that namedropped a referenced record), every string
+ * value in the payload is scanned for substrings that are themselves
+ * keys in `idMap` and rewritten to the importer's regenerated value.
  *
- * Free-form strings throughout an export can embed references to other
- * imported records by inline UUID: claim.text ("ea5f996b-... has collided
- * with 9cc9f799-..."), summary text spans, persona.informationNeed or
- * persona.details that mention a world entity, ontology entityType /
- * eventType / roleType descriptions that namedrop another type, world
- * object name / description fields that cross-reference a sibling object,
- * etc. `remapInlineUuids` substitutes every UUID-shaped substring whose
- * lowercased form lives in the cross-user idMap with its remapped value
- * so the surrounding prose stays consistent with the regenerated row
- * after a cross-user import. UUID-looking strings that the import has no
- * knowledge of (random ids not in the map) are passed through unchanged,
- * so the substitution is a strict no-op outside the cross-user path.
+ * Keys are sorted longest-first so a longer id that happens to contain
+ * a shorter id as a prefix wins. Keys are RegExp-escaped so id formats
+ * containing regex metacharacters (hyphens are fine, but a future short
+ * id format could include dots or parentheses) substitute literally.
+ * The `\b`-free pattern intentionally also rewrites ids that appear as
+ * substrings of larger tokens (e.g. `claim_<id>_v2`, `entity-<id>.png`,
+ * `https://x/<id>?q=1`), since those are the exact shapes inline prose
+ * uses when it namedrops a referenced record. Strings whose substrings
+ * are not in `idMap` pass through unchanged so the substitution stays
+ * a strict no-op outside the cross-user path.
  */
-const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+function escapeRegex(s: string): string {
+  return s.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+}
 
-function remapInlineUuids(text: string, idMap: Map<string, string>): string {
-  if (!text || idMap.size === 0) return text
-  return text.replace(UUID_REGEX, m => idMap.get(m.toLowerCase()) ?? m)
+function buildRemapPattern(idMap: Map<string, string>): RegExp | null {
+  if (idMap.size === 0) return null
+  const keys = Array.from(idMap.keys())
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegex)
+  return new RegExp(keys.join('|'), 'gi')
+}
+
+function remapInlineIds(text: string, pattern: RegExp, idMap: Map<string, string>): string {
+  if (!text) return text
+  pattern.lastIndex = 0
+  return text.replace(pattern, m => idMap.get(m.toLowerCase()) ?? m)
 }
 
 /**
@@ -903,95 +919,61 @@ export class ImportHandler {
    * @returns Updated import lines with remapped IDs
    */
   remapIds(lines: ImportLine[], resolutions: Resolution[]): ImportLine[] {
-    // Build ID mapping
+    // Keys are lowercased so the case-insensitive matcher resolves
+    // uppercase or mixed-case exporter-side ids against the same entry;
+    // values are stored verbatim.
     const idMap = new Map<string, string>()
     for (const resolution of resolutions) {
       if (resolution.newId && resolution.action === 'create-new') {
-        idMap.set(resolution.originalId, resolution.newId)
+        idMap.set(resolution.originalId.toLowerCase(), resolution.newId)
       }
     }
 
-    if (idMap.size === 0) {
+    const pattern = buildRemapPattern(idMap)
+    if (pattern === null) {
       return lines
     }
 
-    // Remap IDs in all lines
     return lines.map(line => {
       const remappedLine = { ...line }
-      remappedLine.data = this.remapObjectIds(line.data, idMap)
+      remappedLine.data = this.remapObjectIds(line.data, idMap, pattern)
       return remappedLine
     })
   }
 
   /**
-   * Recursively remap IDs in an object.
+   * Recursively remap IDs across the imported payload.
+   *
+   * The remap is structure-agnostic: it walks every value in the object
+   * tree and applies the id-shape substitution to every string. The old
+   * implementation gated on a field-name allowlist (`key === 'id'`,
+   * `key.endsWith('Id')`, `key.endsWith('Ids')`, GlossItem `content`),
+   * which had to be extended every time a new id-bearing field was added
+   * to the export schema and silently missed any free-form prose that
+   * mentioned a referenced record by id (including collection `members`
+   * arrays). Building the matcher from the idMap keys themselves makes
+   * the remap independent of field naming: a whole-string id, an id
+   * embedded in surrounding prose, an id array element, an id carried
+   * by a GlossItem `content`, and an id inside a JSON-encoded substring
+   * are all rewritten by the same regex pass against idMap. Substrings
+   * whose lowercased form is not in idMap pass through unchanged so the
+   * substitution is a strict no-op outside the cross-user path.
    */
-  private remapObjectIds(obj: unknown, idMap: Map<string, string>): ImportLine['data'] {
+  private remapObjectIds(obj: unknown, idMap: Map<string, string>, pattern: RegExp): ImportLine['data'] {
+    if (typeof obj === 'string') {
+      return remapInlineIds(obj, pattern, idMap) as unknown as ImportLine['data']
+    }
     if (Array.isArray(obj)) {
-      // Array branches are only reached for nested values (not top-level data).
-      // The index signature [key: string]: unknown on ImportLine['data'] accepts
-      // the array at runtime; bridge the type gap via unknown.
-      const mapped: unknown = obj.map(item => this.remapObjectIds(item, idMap))
-      return mapped as ImportLine['data']
-    } else if (obj && typeof obj === 'object') {
+      return obj.map(item => this.remapObjectIds(item, idMap, pattern)) as unknown as ImportLine['data']
+    }
+    if (obj && typeof obj === 'object') {
       const remapped: ImportLine['data'] = {}
-      // GlossItem references store the target ID in `content` rather than a
-      // *Id-suffixed key; detect these so the content is rewritten too.
-      const glossType = (obj as Record<string, unknown>).type
-      const glossRefType = (obj as Record<string, unknown>).refType
-      const isObjectRef = glossType === 'objectRef' || glossType === 'annotationRef' || glossType === 'claimRef'
-      const isInstanceTypeRef = glossType === 'typeRef' && typeof glossRefType === 'string' &&
-        (glossRefType === 'entity-object' || glossRefType === 'event-object' ||
-         glossRefType === 'time-object' || glossRefType === 'location-object' ||
-         glossRefType === 'annotation' || glossRefType === 'claim')
-
       for (const [key, value] of Object.entries(obj)) {
-        // Scalar id field
-        if (key === 'id' && typeof value === 'string' && idMap.has(value)) {
-          remapped[key] = idMap.get(value)
-        }
-        // Scalar *Id reference field
-        else if (key.endsWith('Id') && typeof value === 'string' && idMap.has(value)) {
-          remapped[key] = idMap.get(value)
-        }
-        // Array of IDs (e.g. entityIds: string[], eventIds: string[])
-        else if (key.endsWith('Ids') && Array.isArray(value) && value.every(v => typeof v === 'string')) {
-          remapped[key] = (value as string[]).map(v => idMap.get(v) ?? v)
-        }
-        // Scalar *Ids stored as a single string (defensive)
-        else if (key.endsWith('Ids') && typeof value === 'string' && idMap.has(value)) {
-          remapped[key] = idMap.get(value)
-        }
-        // GlossItem content carrying a referenced ID
-        else if (key === 'content' && typeof value === 'string' && (isObjectRef || isInstanceTypeRef) && idMap.has(value)) {
-          remapped[key] = idMap.get(value)
-        }
-        // Any other string value can embed inline references to imported
-        // records by UUID: claim.text ("ea5f996b-... has collided with
-        // 9cc9f799-..."), summary text segments, persona.informationNeed
-        // or persona.details that namedrop a world entity, ontology
-        // entityType / eventType / roleType description that cites another
-        // type, world object name / description that cross-references a
-        // sibling, etc. The previous remapObjectIds only walked NAME-
-        // signalled id-reference fields (*Id, *Ids, gloss objectRef.content,
-        // gloss typeRef.content), so any UUID that lived as a free-text
-        // mention inside surrounding prose slipped through and pointed at
-        // an exporter-side row that no longer existed in the importer's
-        // database after the cross-user step regenerated every id. Run the
-        // UUID-shape substitution over every other string value so the
-        // surrounding prose stays consistent with the regenerated rows;
-        // strings whose UUID-shaped substrings are not in the cross-user
-        // idMap (random ids the import has no knowledge of) pass through
-        // unchanged, so the substitution is a strict no-op outside the
-        // cross-user path.
-        else if (typeof value === 'string') {
-          remapped[key] = remapInlineUuids(value, idMap)
-        }
-        // Recurse into nested objects and arrays
-        else if (typeof value === 'object' && value !== null) {
-          remapped[key] = this.remapObjectIds(value, idMap)
-        }
-        else {
+        if (typeof value === 'string') {
+          remapped[key] = remapInlineIds(value, pattern, idMap)
+        } else if (value !== null && typeof value === 'object') {
+          remapped[key] = this.remapObjectIds(value, idMap, pattern)
+        } else {
           remapped[key] = value
         }
       }

--- a/server/test/integration/import-export-fidelity.test.ts
+++ b/server/test/integration/import-export-fidelity.test.ts
@@ -135,6 +135,11 @@ describe('Import/export field-level round-trip fidelity', () => {
     if (key.endsWith('Id') || key.endsWith('Ids')) return true
     // v0.2.0+: ownership-tagging fields the import handler always rewrites.
     if (key === 'createdBy' || key === 'createdByUserId') return true
+    // Collection reference arrays: entityCollections / eventCollections /
+    // timeCollections each carry a `members` array whose elements are ids
+    // of the referenced entities / events / times. Those are remapped on
+    // cross-user import alongside the records they reference.
+    if (key === 'members') return true
     return false
   }
 

--- a/server/test/services/import-handler-remap-ids.test.ts
+++ b/server/test/services/import-handler-remap-ids.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest'
+import { PrismaClient } from '@prisma/client'
+import { ImportHandler } from '../../src/services/import-handler.js'
+import { ImportLine, Resolution } from '../../src/services/import-types.js'
+
+/**
+ * Pure-unit coverage for ImportHandler.remapIds. No database needed: the
+ * remap operates on parsed JSONL lines via an in-memory idMap, so we
+ * construct a stub PrismaClient and exercise the structure-agnostic
+ * id-shape substitution directly.
+ *
+ * The exhaustive surface this asserts is the contract behind the
+ * cross-user import fix: every substring of every string value in the
+ * payload that is itself a key of idMap (case-insensitive) is rewritten
+ * to the importer's regenerated id, no matter what field carries it,
+ * how deeply it is nested, whether it appears alone or embedded in
+ * prose, or whether the prose is itself a JSON-encoded blob.
+ */
+
+const prisma = {} as PrismaClient
+
+const ID_A = '11111111-1111-4111-8111-111111111111'
+const ID_B = '22222222-2222-4222-8222-222222222222'
+const ID_C = '33333333-3333-4333-8333-333333333333'
+const ID_D = '44444444-4444-4444-8444-444444444444'
+
+const NEW_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const NEW_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const NEW_C = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const NEW_D = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+
+const RESOLUTIONS: Resolution[] = [
+  { conflictType: 'persona' as never, strategy: 'create-new', originalId: ID_A, newId: NEW_A, action: 'create-new' },
+  { conflictType: 'entity' as never,  strategy: 'create-new', originalId: ID_B, newId: NEW_B, action: 'create-new' },
+  { conflictType: 'claim' as never,   strategy: 'create-new', originalId: ID_C, newId: NEW_C, action: 'create-new' },
+  { conflictType: 'summary' as never, strategy: 'create-new', originalId: ID_D, newId: NEW_D, action: 'create-new' },
+]
+
+function line(type: string, data: ImportLine['data']): ImportLine {
+  return { type: type as ImportLine['type'], data, lineNumber: 1 }
+}
+
+function run(lines: ImportLine[]): ImportLine[] {
+  const handler = new ImportHandler(prisma, 'importer-user')
+  return handler.remapIds(lines, RESOLUTIONS)
+}
+
+describe('ImportHandler.remapIds — id-shape substitution', () => {
+  it('rewrites an id that fills an entire string value, regardless of field name', () => {
+    const out = run([
+      line('persona', { id: ID_A }),
+      line('annotation', { personaId: ID_A, linkedEntityId: ID_B }),
+      line('claim', { id: ID_C, subjectEntity: ID_B }),
+    ])
+    expect(out[0].data.id).toBe(NEW_A)
+    expect(out[1].data.personaId).toBe(NEW_A)
+    expect(out[1].data.linkedEntityId).toBe(NEW_B)
+    expect(out[2].data.id).toBe(NEW_C)
+    expect(out[2].data.subjectEntity).toBe(NEW_B)
+  })
+
+  it('rewrites inline id mentions embedded in surrounding prose', () => {
+    const out = run([
+      line('claim', {
+        id: ID_C,
+        text: `Entity ${ID_B} attempts to break a gate near entity ${ID_A}.`,
+        comment: `See also entity ${ID_B} earlier in the timeline.`,
+      }),
+    ])
+    expect(out[0].data.text).toBe(`Entity ${NEW_B} attempts to break a gate near entity ${NEW_A}.`)
+    expect(out[0].data.comment).toBe(`See also entity ${NEW_B} earlier in the timeline.`)
+  })
+
+  it('rewrites ids in every free-form field the export schema can populate', () => {
+    const out = run([
+      line('persona', {
+        id: ID_A,
+        informationNeed: `Track ${ID_B} across all videos.`,
+        details: `Persona observes entity ${ID_B} alongside claim ${ID_C}.`,
+      }),
+      line('ontology', {
+        types: [
+          { id: ID_B, description: `Used in conjunction with entity ${ID_B}.` },
+        ],
+      }),
+      line('world-state', {
+        entities: [
+          { id: ID_B, name: `Sibling of ${ID_B}`, description: `Mirrors entity ${ID_B} above.` },
+        ],
+      }),
+      line('summary', {
+        id: ID_D,
+        text: `Summary mentioning entity ${ID_B} and claim ${ID_C}.`,
+      }),
+      line('claim-relation', {
+        subjectClaim: ID_C,
+        objectClaim: ID_C,
+        relationDescription: `Connects ${ID_C} to ${ID_B}.`,
+      }),
+    ])
+    expect(out[0].data.informationNeed).toBe(`Track ${NEW_B} across all videos.`)
+    expect(out[0].data.details).toBe(`Persona observes entity ${NEW_B} alongside claim ${NEW_C}.`)
+    expect((out[1].data.types as Array<{ description: string }>)[0].description)
+      .toBe(`Used in conjunction with entity ${NEW_B}.`)
+    expect((out[2].data.entities as Array<{ name: string; description: string }>)[0].name)
+      .toBe(`Sibling of ${NEW_B}`)
+    expect((out[2].data.entities as Array<{ description: string }>)[0].description)
+      .toBe(`Mirrors entity ${NEW_B} above.`)
+    expect(out[3].data.text).toBe(`Summary mentioning entity ${NEW_B} and claim ${NEW_C}.`)
+    expect(out[4].data.relationDescription).toBe(`Connects ${NEW_C} to ${NEW_B}.`)
+  })
+
+  it('rewrites ids nested arbitrarily deep, including through arrays', () => {
+    const out = run([
+      line('claim', {
+        id: ID_C,
+        gloss: {
+          items: [
+            { type: 'objectRef', content: ID_B },
+            { type: 'text', content: `references ${ID_B}` },
+            { type: 'typeRef', refType: 'entity-object', content: ID_B },
+            { type: 'group', children: [{ type: 'objectRef', content: ID_A }] },
+          ],
+        },
+      }),
+    ])
+    const items = (out[0].data.gloss as { items: Array<{ type: string; content?: string; children?: Array<{ content: string }> }> }).items
+    expect(items[0].content).toBe(NEW_B)
+    expect(items[1].content).toBe(`references ${NEW_B}`)
+    expect(items[2].content).toBe(NEW_B)
+    expect(items[3].children![0].content).toBe(NEW_A)
+  })
+
+  it('rewrites each element of *Ids arrays, members arrays, and ordinary string arrays', () => {
+    const out = run([
+      line('annotation', {
+        entityIds: [ID_A, ID_B, ID_C],
+        tags: [`primary:${ID_A}`, `secondary:${ID_B}`],
+      }),
+      line('entity-collection', {
+        members: [ID_A, ID_B],
+      }),
+    ])
+    expect(out[0].data.entityIds).toEqual([NEW_A, NEW_B, NEW_C])
+    expect(out[0].data.tags).toEqual([`primary:${NEW_A}`, `secondary:${NEW_B}`])
+    expect(out[1].data.members).toEqual([NEW_A, NEW_B])
+  })
+
+  it('rewrites multiple ids in a single string', () => {
+    const out = run([
+      line('claim', {
+        text: `${ID_A} → ${ID_B} → ${ID_C} → ${ID_A} (cycle)`,
+      }),
+    ])
+    expect(out[0].data.text).toBe(`${NEW_A} → ${NEW_B} → ${NEW_C} → ${NEW_A} (cycle)`)
+  })
+
+  it('rewrites ids embedded as substrings inside larger tokens', () => {
+    const out = run([
+      line('claim', {
+        text: `claim_${ID_C}_v2 references entity-${ID_B}.png and url=https://x/${ID_A}?q=1`,
+      }),
+    ])
+    expect(out[0].data.text).toBe(
+      `claim_${NEW_C}_v2 references entity-${NEW_B}.png and url=https://x/${NEW_A}?q=1`,
+    )
+  })
+
+  it('rewrites ids whose case differs from the exporter-side originalId', () => {
+    const out = run([
+      line('claim', {
+        text: `Refers to ${ID_B.toUpperCase()} and to ${ID_C.toUpperCase()}.`,
+        someId: ID_A.toUpperCase(),
+      }),
+    ])
+    expect(out[0].data.text).toBe(`Refers to ${NEW_B} and to ${NEW_C}.`)
+    expect(out[0].data.someId).toBe(NEW_A)
+  })
+
+  it('rewrites ids embedded inside a JSON-encoded blob carried as a string', () => {
+    const encoded = JSON.stringify({ ref: ID_B, note: `near ${ID_C}` })
+    const out = run([
+      line('claim', { rawPayload: encoded }),
+    ])
+    expect(out[0].data.rawPayload).toBe(
+      JSON.stringify({ ref: ID_B, note: `near ${ID_C}` })
+        .replace(ID_B, NEW_B)
+        .replace(ID_C, NEW_C),
+    )
+  })
+
+  it('passes id-shaped substrings that are NOT in the idMap through unchanged', () => {
+    const stranger = 'deadbeef-dead-4bee-8eef-feedfacecafe'
+    const out = run([
+      line('claim', {
+        id: ID_C,
+        text: `Imported claim sits next to ${stranger}, an id this import has never seen.`,
+      }),
+    ])
+    expect(out[0].data.id).toBe(NEW_C)
+    expect(out[0].data.text).toBe(
+      `Imported claim sits next to ${stranger}, an id this import has never seen.`,
+    )
+  })
+
+  it('passes strings whose substrings are not in the map through unchanged (no false positives)', () => {
+    const out = run([
+      line('claim', {
+        text: 'plain prose with hex 0a09067725832030 and short ids abc-123',
+        nonsense: '11111111-1111-1111-1111-1111111111ZZ',
+      }),
+    ])
+    expect(out[0].data.text).toBe('plain prose with hex 0a09067725832030 and short ids abc-123')
+    expect(out[0].data.nonsense).toBe('11111111-1111-1111-1111-1111111111ZZ')
+  })
+
+  it('is a strict no-op when no resolutions request create-new', () => {
+    const handler = new ImportHandler(prisma, 'importer')
+    const lines: ImportLine[] = [
+      line('claim', { id: ID_C, text: `mentions ${ID_B}` }),
+    ]
+    const out = handler.remapIds(lines, [
+      { conflictType: 'claim' as never, strategy: 'skip', originalId: ID_C, action: 'skip' },
+    ])
+    expect(out).toEqual(lines)
+  })
+
+  it('leaves primitive non-string, non-object values (numbers, booleans, null) untouched', () => {
+    const out = run([
+      line('annotation', {
+        startFrame: 0,
+        endFrame: 240,
+        isApproved: true,
+        deletedAt: null,
+        text: `linked to ${ID_B}`,
+      }),
+    ])
+    expect(out[0].data.startFrame).toBe(0)
+    expect(out[0].data.endFrame).toBe(240)
+    expect(out[0].data.isApproved).toBe(true)
+    expect(out[0].data.deletedAt).toBeNull()
+    expect(out[0].data.text).toBe(`linked to ${NEW_B}`)
+  })
+})


### PR DESCRIPTION
## Summary

- Forward-ports the v0.3.3 generalisation of the cross-user id remap from `release/0.3.x` to `main`.
- Replaces `remapObjectIds`'s field-name allowlist (`id` / `*Id` / `*Ids` / gloss-`content`) with a structure-agnostic substitution built from the cross-user `idMap` keys themselves: case-insensitive, sorted longest-first, RegExp-escaped, applied to every string in the payload tree.
- Closes two real correctness gaps the prior allowlist hid: `entityCollection.members` / `eventCollection.members` / `timeCollection.members` were never remapped, and any future id-bearing field whose name fell outside the allowlist would silently miss the same way.
- Adds `server/test/services/import-handler-remap-ids.test.ts` (13 pure-unit tests, no DB) covering every free-text surface, nested arrays / gloss `items`, `*Ids` arrays, `members` arrays, multi-id strings, ids embedded in larger tokens, mixed-case ids, JSON-encoded blobs, ids-not-in-map untouched, and primitives untouched. Full server suite verified green on `release/0.1.x` / `release/0.2.x` / `release/0.3.x` / `refactor/shadcn-ui-migration` (938 / 1128 / 1128 / 1132 tests respectively).

## Test plan

- [x] Full vitest suite on each affected branch (4 branches, 4326 tests total) — all green.
- [x] Cross-user import integration suites (`cross-user-import-foreign-fixture`, `cross-user-import-real-fixture`, `import-export-cross-user`, `import-export-fidelity`, `import-export-edges`) — all green.
- [x] New unit suite (`import-handler-remap-ids.test.ts`, 13 tests) — green.
- [x] Typecheck (`tsc --noEmit`) and lint (`eslint`) — clean on all four branches.
- [x] Release workflow on tag push — green for `v0.1.10` / `v0.2.3` / `v0.3.3`.
- [ ] Verify CI on this PR before merge.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Performance improvement
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules