### PR TITLE
fix: stop release.yml timing out at the 6h ceiling (amd64-only, free disk, job timeout)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   build-and-push-images:
     name: Build Release Images
     runs-on: ubuntu-latest
+    # Backstop so a wedged build (historically the disk-starved GPU image)
+    # fails fast instead of burning the full 6 h GitHub Actions job ceiling.
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -27,14 +30,20 @@ jobs:
           # the package directory the COPY annotation-tool/... line
           # resolves to <context>/annotation-tool which does not
           # exist (it would be /annotation-tool/annotation-tool).
+          # amd64 only: the prior linux/amd64,linux/arm64 matrix built the
+          # arm64 variant under QEMU emulation (10-50x slower), pushing the
+          # frontend/backend jobs toward the 6 h ceiling. docker.yml (the dev
+          # image workflow) ships amd64-only and these release images match it.
+          # If arm64 images are ever required, build them on native
+          # ubuntu-*-arm runners and merge manifests rather than emulating.
           - name: frontend
             context: .
             file: annotation-tool/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: backend
             context: .
             file: server/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           # model-service entries keep their context at ./model-service
           # because the Dockerfile COPYs `pyproject.toml`, `src`, `config`,
           # `scripts` from paths relative to the package, not the repo
@@ -55,8 +64,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # The model-service "full" GPU image (CUDA + the entire ML stack) is
+      # multi-GB and exhausts the stock runner's ~14 GB free disk mid-build,
+      # which is what stalled the prior release runs to the 6 h ceiling.
+      # Reclaim ~25 GB of preinstalled toolchains first, matching docker.yml.
+      # (QEMU is gone: every image now builds amd64-native, no emulation.)
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af --volumes
+          df -h
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description

The `Release` workflow (`release.yml`, triggered on `v*.*.*` tags) has timed out at the 6 h GitHub Actions job ceiling on the last two releases (v0.4.1, v0.4.2 both ended **cancelled** at ~6h), so versioned images never publish to GHCR. Root cause, by comparison with the working `docker.yml`:

1. **`frontend` + `backend` built `linux/amd64,linux/arm64`** — the arm64 variant runs under QEMU emulation (10–50× slower). `docker.yml` ships amd64-only.
2. **No disk cleanup before the multi-GB `model-service-gpu` ("full" CUDA + ML stack) image** — it exhausts the stock runner's ~14 GB free disk mid-build and stalls. `docker.yml` runs a "Free up disk space" step (and never builds the GPU image at all).
3. **No `timeout-minutes`** — a wedged build burns the full 6 h instead of failing fast.

This PR fixes all three.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

Fixes # (release workflow timeout; no tracking issue)
Relates to # the v0.4.3 release

## Changes Made

- `frontend` and `backend` matrix entries build `platforms: linux/amd64` only (was `linux/amd64,linux/arm64`).
- Removed the now-unused `Set up QEMU` step (no emulated arch remains) and added the `Free up disk space` step (reclaims ~25 GB of preinstalled toolchains), matching `docker.yml`.
- Added `timeout-minutes: 90` to the `build-and-push-images` job as a fast-fail backstop.

## Testing

### Test Environment

- OS: GitHub-hosted `ubuntu-latest` runners
- Browser (if applicable): n/a
- Node version: n/a
- Python version (if applicable): n/a

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. YAML validated locally (`yaml.safe_load`): all four matrix entries are `linux/amd64`, `timeout-minutes: 90` present, `Free up disk space` step present, QEMU step removed.
2. The real proof is the next tagged release run completing well under 90 minutes (see "Additional Notes" for re-cutting v0.4.3).

## Screenshots/Videos

<!-- n/a -->

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [ ] No significant performance impact
- [x] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: removes QEMU arm64 emulation and the disk-exhaustion stall from the release build; runs should drop from "6 h timeout" to minutes.

## Breaking Changes

**Breaking changes:**
- Release images are now published for `linux/amd64` only (arm64 variants of frontend/backend are no longer pushed). This matches `docker.yml`'s dev images. If arm64 release images are required, the correct fix is native `ubuntu-*-arm` runners + manifest merge (noted in a code comment), not QEMU.

**Migration guide:**
- None for amd64 consumers (the deploy server and CI). Apple-Silicon local dev builds images locally via `docker-compose.local-full.yml`, so it is unaffected.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`release.yml` is read from the **tagged commit**, so the in-flight v0.4.3 release run is still using the old (broken) workflow and will time out. To publish v0.4.3 images with this fix: merge this PR, then re-cut the tag — `git tag -d v0.4.3 && git push origin :refs/tags/v0.4.3` then re-tag `v0.4.3` on the commit that includes this fix and push. (The production deploy already succeeded independently; this only affects GHCR image publication.)

## Reviewer Guidance

Single-file change to `.github/workflows/release.yml`; compare against `.github/workflows/docker.yml`, which already uses the amd64-only + free-disk pattern this aligns to.
