### PR TITLE
build: local-full model-service uses recommended build mode (not full) for macOS arm64

### DIFF
--- a/docker-compose.local-full.yml
+++ b/docker-compose.local-full.yml
@@ -15,7 +15,18 @@ services:
       context: ./model-service
       dockerfile: Dockerfile
       args:
-        BUILD_MODE: minimal
+        # recommended = base + bitsandbytes (no vllm / sglang / sam-2).
+        # The CVPR booth backup laptop exercises VLM summarization,
+        # LLM ontology + claim extraction, ONNX object detection,
+        # faster-whisper transcription, and pyannote speaker
+        # diarization — every one of which runs cleanly on the
+        # recommended set. full pulls sam-2 from a github clone +
+        # vllm + sglang which inflate the image past 8 GB and
+        # silently fail the Dockerfile retry block on macOS arm64
+        # (sam-2's CUDA-flavoured build script). ENABLE_AUDIO=1
+        # still pins CPU-only torch wheels before pyannote so
+        # libcudart.so is never linked.
+        BUILD_MODE: recommended
         DEVICE: cpu
         ENABLE_AUDIO: 1
         PRELOAD_MODELS: false


### PR DESCRIPTION
## Description

Switches the `local-full` model-service build arg from `BUILD_MODE: minimal` to `recommended` (base + bitsandbytes). This change was already present in the working tree; committing it so it isn't lost. The `full` set pulls sam-2 (a CUDA-flavoured GitHub-clone build) + vllm + sglang, which inflate the image past 8 GB and silently fail the Dockerfile retry block on macOS arm64; `recommended` covers every path the CVPR booth backup laptop exercises (VLM summarization, LLM ontology + claim extraction, ONNX detection, faster-whisper transcription, pyannote diarization). `ENABLE_AUDIO=1` still pins CPU-only torch wheels before pyannote.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

Relates to # the CVPR booth local-full stack

## Changes Made

- `docker-compose.local-full.yml`: model-service `BUILD_MODE` `minimal` → `recommended`, with an inline comment documenting why `full` is avoided on macOS arm64.

## Testing

### Test Environment

- OS: macOS arm64 (booth backup laptop)
- Browser (if applicable): n/a
- Node version: n/a
- Python version (if applicable): n/a

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [ ] All existing tests pass

### How to Test

1. `docker compose -f docker-compose.local-full.yml build model-service` on macOS arm64 completes without the sam-2/vllm/sglang retry failure.

## Screenshots/Videos

<!-- n/a -->

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [ ] CHANGELOG updated (for user-visible changes)
- [x] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: local-only compose; no runtime/perf impact on deployed services.

## Breaking Changes

**Breaking changes:**
- None (local-full dev/booth stack only).

**Migration guide:**
- None.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This was an in-tree change carried over from before the v0.4.3 work; isolating it in its own PR rather than bundling it with unrelated changes.

## Reviewer Guidance

One-line build-arg change plus an explanatory comment; affects only the local-full compose stack.
