### PR TITLE
chore: v0.4.4 architecture roadmap Phase 0 reversible cleanups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,11 +104,11 @@ WIKIDATA_MODE=online
 # ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS=true # Controls video source links (uploaderUrl, webpageUrl)
 
 # Port Configuration (host ports)
+# REDIS_PORT is defined once in the Redis Configuration section above.
 FRONTEND_PORT=3000
 BACKEND_PORT=3001
 MODEL_SERVICE_PORT=8000
 POSTGRES_PORT=5432
-REDIS_PORT=6379
 PROMETHEUS_PORT=9090
 GRAFANA_PORT=3002
 OTEL_GRPC_PORT=4317

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-06-17
+
+The first installment of the architecture-modularization roadmap (`notes/architecture-review.md`, Phase 0): reversible cleanups with no user-facing behavior change — dead dependencies removed, a configuration template de-duplicated, and one latent model-loader gap closed with a regression guard.
+
+### Removed
+
+#### Unused Backend Dependencies
+
+- Dropped `cors`, `express`, and `multer` (and their `@types/cors`, `@types/express`, `@types/multer` type packages) from `server/package.json`. The backend is entirely Fastify and imports `@fastify/cors`; these three packages had zero import sites in `server/src`. `pnpm-lock.yaml` was regenerated, removing them and their now-orphaned transitive dependencies.
+
+### Fixed
+
+#### SAM 3.1 Object Detection Had No Loader Path
+
+- `_object_detection_factory` (`model-service/src/infrastructure/config/task_factories.py`) was missing the `framework == "sam3"` pre-dispatch that `_object_tracking_factory` already had, so an `object_detection` model selecting SAM 3.1 (`config/models.yaml`, `selected: "sam-3-1"`) routed to the architecture-keyed detection registry — which registers no SAM3 loader — and would raise `UnknownArchitectureError` at load time. The factory now pre-dispatches `framework == "sam3"` to the existing, contract-tested `SAM3DetectionAdapter` via `SAM3Loader`, matching the tracking path. The `SAM3Detection`/`SAM3Tracking` architecture classes are deliberately registry-less (SAM3 loads through framework pre-dispatch, and the classes exist so SAM3 YAML entries carry a schema-valid `architecture:` block), so nothing was removed.
+- Added `model-service/test/config/test_catalog_dispatch_invariant.py`, a bidirectional architecture-to-loader invariant test: every `architecture.kind` across `models.yaml` and `models-cpu.yaml` must resolve to a registered loader, a documented framework pre-dispatch (`sam3`, `external_api`), or a dedicated task factory (speaker diarization, voice-activity detection), and every registered loader must target a valid architecture-family union member. Reverting the SAM3 detection fix makes this suite fail, so a future un-wired architecture is caught in CI rather than at model load.
+
+### Changed
+
+#### Configuration Template De-duplication
+
+- Removed the duplicate `REDIS_PORT` declaration from `.env.example` (it appeared in both the Redis-configuration and host-ports sections; duplicate dotenv keys are silently last-wins). The key is now defined once, in the Redis-configuration section, with a pointer comment where the host-ports list previously repeated it.
+- Synchronized the two package manifests that had drifted behind the release version (`model-service/package.json` and `wikibase/pyproject.toml` were still at `0.4.0`); all seven package manifests now report `0.4.4`.
+
 ## [0.4.3] - 2026-06-17
 
 This release works through the open issue backlog: it closes three issues that were already resolved on `main` (verified by running their tests) and fixes four that were still outstanding.

--- a/annotation-tool/package.json
+++ b/annotation-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fovea/annotation-tool",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -11,6 +11,30 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-06-17
+
+The first installment of the architecture-modularization roadmap (`notes/architecture-review.md`, Phase 0): reversible cleanups with no user-facing behavior change — dead dependencies removed, a configuration template de-duplicated, and one latent model-loader gap closed with a regression guard.
+
+### Removed
+
+#### Unused Backend Dependencies
+
+- Dropped `cors`, `express`, and `multer` (and their `@types/cors`, `@types/express`, `@types/multer` type packages) from `server/package.json`. The backend is entirely Fastify and imports `@fastify/cors`; these three packages had zero import sites in `server/src`. `pnpm-lock.yaml` was regenerated, removing them and their now-orphaned transitive dependencies.
+
+### Fixed
+
+#### SAM 3.1 Object Detection Had No Loader Path
+
+- `_object_detection_factory` (`model-service/src/infrastructure/config/task_factories.py`) was missing the `framework == "sam3"` pre-dispatch that `_object_tracking_factory` already had, so an `object_detection` model selecting SAM 3.1 (`config/models.yaml`, `selected: "sam-3-1"`) routed to the architecture-keyed detection registry — which registers no SAM3 loader — and would raise `UnknownArchitectureError` at load time. The factory now pre-dispatches `framework == "sam3"` to the existing, contract-tested `SAM3DetectionAdapter` via `SAM3Loader`, matching the tracking path. The `SAM3Detection`/`SAM3Tracking` architecture classes are deliberately registry-less (SAM3 loads through framework pre-dispatch, and the classes exist so SAM3 YAML entries carry a schema-valid `architecture:` block), so nothing was removed.
+- Added `model-service/test/config/test_catalog_dispatch_invariant.py`, a bidirectional architecture-to-loader invariant test: every `architecture.kind` across `models.yaml` and `models-cpu.yaml` must resolve to a registered loader, a documented framework pre-dispatch (`sam3`, `external_api`), or a dedicated task factory (speaker diarization, voice-activity detection), and every registered loader must target a valid architecture-family union member. Reverting the SAM3 detection fix makes this suite fail, so a future un-wired architecture is caught in CI rather than at model load.
+
+### Changed
+
+#### Configuration Template De-duplication
+
+- Removed the duplicate `REDIS_PORT` declaration from `.env.example` (it appeared in both the Redis-configuration and host-ports sections; duplicate dotenv keys are silently last-wins). The key is now defined once, in the Redis-configuration section, with a pointer comment where the host-ports list previously repeated it.
+- Synchronized the two package manifests that had drifted behind the release version (`model-service/package.json` and `wikibase/pyproject.toml` were still at `0.4.0`); all seven package manifests now report `0.4.4`.
+
 ## [0.4.3] - 2026-06-17
 
 This release works through the open issue backlog: it closes three issues that were already resolved on `main` (verified by running their tests) and fixes four that were still outstanding.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/model-service/package.json
+++ b/model-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fovea-model-service",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "description": "AI model inference service for video annotation",
   "scripts": {
     "dev": "source venv/bin/activate && uvicorn src.main:app --reload --host 0.0.0.0 --port 8000",

--- a/model-service/pyproject.toml
+++ b/model-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fovea-model-service"
-version = "0.4.3"
+version = "0.4.4"
 description = "Model service for fovea video annotation tool"
 requires-python = ">=3.12"
 dependencies = [

--- a/model-service/src/infrastructure/config/task_factories.py
+++ b/model-service/src/infrastructure/config/task_factories.py
@@ -100,14 +100,28 @@ def _vad_factory(model_config: ModelConfig) -> Any:
 
 
 def _object_detection_factory(model_config: ModelConfig) -> Any:
-    """Build a detection loader from config based on the ``framework`` hint.
+    """Build a detection loader, preferring SAM 3.1 when ``framework`` selects it.
 
-    Dispatch is purely architecture-keyed: the architecture Pydantic
-    model parsed from the YAML's ``architecture:`` block selects the
-    loader class via the registry, and the ``framework`` enum on
-    :class:`DetectionConfig` selects between the pytorch and ONNX
-    registries. No code on this path inspects ``model_id`` strings.
+    The SAM 3.1 path is a framework-level pre-dispatch: the SAM3 adapter lives
+    in its own module with its own loading conventions and is selected by the
+    ``framework: "sam3"`` YAML hint before the architecture-keyed registry is
+    consulted. Every other detection entry is architecture-keyed: the
+    architecture Pydantic model parsed from the YAML's ``architecture:`` block
+    selects the loader class via the registry, and the ``framework`` enum on
+    :class:`DetectionConfig` selects between the pytorch and ONNX registries.
+    No code on the architecture-keyed path inspects ``model_id`` strings.
     """
+    if model_config.framework == "sam3":
+        from src.infrastructure.adapters.outbound.models.sam3 import (  # noqa: PLC0415
+            SAM3DetectionAdapter,
+            SAM3Loader,
+        )
+
+        sam3_loader = SAM3Loader(model_id=model_config.model_id, device=_device())
+        sam3_loader.load()
+        logger.info(f"SAM 3.1 detection loaded: {model_config.model_id}")
+        return SAM3DetectionAdapter(sam3_loader)
+
     from src.infrastructure.adapters.outbound.models.detection.loader import (  # noqa: PLC0415
         DetectionConfig,
         DetectionFramework,

--- a/model-service/test/config/test_catalog_dispatch_invariant.py
+++ b/model-service/test/config/test_catalog_dispatch_invariant.py
@@ -1,0 +1,411 @@
+"""Bidirectional invariant linking the model catalog to the loader registries.
+
+Every model option the service ships in ``config/models.yaml`` and
+``config/models-cpu.yaml`` must be loadable, and every loader the service
+registers must target an architecture that the catalog schema can actually
+express. This module asserts both directions so a catalog entry can never
+reference a dispatch path that does not exist, and a loader can never bind to
+an architecture outside its family union.
+
+Dispatch is not "purely architecture-keyed" across the whole service. Two
+documented framework-level pre-dispatches run before the architecture-keyed
+registries are consulted, and two audio tasks route through dedicated task
+factories rather than a registry. The forward assertion encodes every one of
+those paths explicitly so it stays faithful to what the task factories in
+:mod:`src.infrastructure.config.task_factories` actually do:
+
+* ``framework == "external_api"`` routes through the external-API adapter
+  layer; no local loader registers for these marker architectures.
+* ``framework == "sam3"`` routes through the SAM 3.1 adapter pre-dispatch
+  (``SAM3DetectionAdapter`` for detection, ``SAM3TrackingAdapter`` for
+  tracking); no loader registers ``SAM3Detection`` or ``SAM3Tracking`` in the
+  detection or tracking registries.
+* ``speaker_diarization`` and ``voice_activity_detection`` are built by the
+  ``PyannoteLoader`` / ``SileroVADLoader`` task factories directly; their
+  architectures are intentionally absent from ``audio_registry``.
+* Every remaining catalog option is architecture-keyed and must resolve to a
+  registered loader in the registry that owns its task section.
+
+The forward direction is the assertion that would have caught the un-wired
+SAM 3.1 detection path: an ``object_detection`` option carrying
+``framework: "sam3"`` resolves through the SAM 3.1 pre-dispatch only because
+that branch now exists in ``_object_detection_factory``; without it the option
+would fall through to the detection registry, which has no ``SAM3Detection``
+loader, and this test would fail.
+"""
+
+from __future__ import annotations
+
+import typing
+from pathlib import Path
+from typing import Protocol
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from pydantic import BaseModel
+
+from src.application.services.model_management import ModelConfig
+from src.domain.entities.architectures import (
+    Architecture,
+    AudioArchitecture,
+    DetectionArchitecture,
+    LLMArchitecture,
+    TrackingArchitecture,
+    VLMArchitecture,
+)
+
+# The same discriminated-union adapter ModelConfig uses to parse the
+# ``architecture`` block of every catalog option. Reusing it means this test
+# parses the catalog exactly as the application does instead of hand-rolling
+# kind extraction.
+from src.domain.entities.model_config import _ARCHITECTURE_ADAPTER
+
+# Importing the loader modules executes their ``@*_registry.register(...)``
+# decorators (including the side-effect imports each module performs at the
+# bottom of its file), so the registries are fully populated by import time.
+# The registries are operated on as data; no model is downloaded or loaded.
+from src.infrastructure.adapters.outbound.models.audio.loader import audio_registry
+from src.infrastructure.adapters.outbound.models.detection.loader import (
+    detection_onnx_registry,
+    detection_pytorch_registry,
+)
+from src.infrastructure.adapters.outbound.models.llm.loader import llm_registry
+from src.infrastructure.adapters.outbound.models.tracking.loader import tracking_registry
+from src.infrastructure.adapters.outbound.models.vlm.loader import vlm_registry
+
+
+class _RegistryView(Protocol):
+    """The slice of a :class:`LoaderRegistry` this invariant reads.
+
+    The catalog families register loaders of different types, so the concrete
+    registry generics differ. This Protocol captures only the read-only surface
+    the invariant needs, which is shared by every registry regardless of its
+    loader type parameter.
+    """
+
+    @property
+    def family(self) -> str:
+        """Short label naming the registry's family."""
+        ...
+
+    @property
+    def registered_architectures(self) -> list[type[BaseModel]]:
+        """Architecture classes the registry currently holds."""
+        ...
+
+
+# Frameworks that bypass every local loader registry. They are handled at the
+# application layer (external_api) or by a dedicated framework pre-dispatch in
+# the task factory (sam3) and so are reachable without a registry entry.
+_PREDISPATCH_FRAMEWORKS = frozenset({"external_api", "sam3"})
+
+# Task sections whose options are built by a dedicated task factory rather than
+# an architecture-keyed registry. The PyannoteLoader / SileroVADLoader paths
+# take only a ``model_id`` and ``device``; their architectures are valid union
+# members but never enter ``audio_registry``.
+_DEDICATED_FACTORY_TASKS = frozenset({"speaker_diarization", "voice_activity_detection"})
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CATALOG_PATHS = (
+    _PROJECT_ROOT / "config" / "models.yaml",
+    _PROJECT_ROOT / "config" / "models-cpu.yaml",
+)
+
+
+def _union_members(alias: object) -> set[type[BaseModel]]:
+    """Return the architecture classes inside an ``Annotated[Union[...], ...]`` alias.
+
+    The family aliases in :mod:`src.domain.entities.architectures` wrap a
+    ``Union`` of architecture classes in ``Annotated[..., Field(discriminator)]``.
+    This unwraps the ``Annotated`` layer, then the ``Union`` layer, and returns
+    the member classes.
+
+    Args:
+        alias: A family architecture alias (for example
+            :data:`DetectionArchitecture`).
+
+    Returns:
+        The set of architecture classes that compose the union.
+    """
+    annotated_args = typing.get_args(alias)
+    union = annotated_args[0]
+    members: set[type[BaseModel]] = set()
+    for member in typing.get_args(union):
+        if isinstance(member, type) and issubclass(member, BaseModel):
+            members.add(member)
+    return members
+
+
+def _kind_to_class(alias: object) -> dict[str, type[BaseModel]]:
+    """Map each architecture's ``kind`` literal to its class for one family.
+
+    Args:
+        alias: A family architecture alias.
+
+    Returns:
+        Mapping from the ``kind`` discriminator string to the architecture
+        class that declares it.
+    """
+    mapping: dict[str, type[BaseModel]] = {}
+    for member in _union_members(alias):
+        kind_field = member.model_fields["kind"]
+        mapping[str(kind_field.default)] = member
+    return mapping
+
+
+# Architecture classes grouped by the registry that owns each task section.
+# A catalog option in a given task section, when it is architecture-keyed,
+# must resolve to a loader registered in the matching registry.
+_DETECTION_KIND_TO_CLASS = _kind_to_class(DetectionArchitecture)
+_TRACKING_KIND_TO_CLASS = _kind_to_class(TrackingArchitecture)
+_AUDIO_KIND_TO_CLASS = _kind_to_class(AudioArchitecture)
+_VLM_KIND_TO_CLASS = _kind_to_class(VLMArchitecture)
+_LLM_KIND_TO_CLASS = _kind_to_class(LLMArchitecture)
+
+# Mapping from a catalog task-section name to the (kind -> class) table and the
+# registries that may satisfy an architecture-keyed option in that section.
+# Detection lists both registries because the framework hint (pytorch vs onnx)
+# picks one at load time; an option is reachable if either registry has it.
+_TASK_DISPATCH: dict[str, tuple[dict[str, type[BaseModel]], tuple[_RegistryView, ...]]] = {
+    "object_detection": (
+        _DETECTION_KIND_TO_CLASS,
+        (detection_pytorch_registry, detection_onnx_registry),
+    ),
+    "video_tracking": (_TRACKING_KIND_TO_CLASS, (tracking_registry,)),
+    "audio_transcription": (_AUDIO_KIND_TO_CLASS, (audio_registry,)),
+    "video_summarization": (_VLM_KIND_TO_CLASS, (vlm_registry,)),
+    "ontology_augmentation": (_LLM_KIND_TO_CLASS, (llm_registry,)),
+    "claim_extraction": (_LLM_KIND_TO_CLASS, (llm_registry,)),
+    "claim_synthesis": (_LLM_KIND_TO_CLASS, (llm_registry,)),
+}
+
+_ALL_REGISTRIES: tuple[_RegistryView, ...] = (
+    detection_pytorch_registry,
+    detection_onnx_registry,
+    tracking_registry,
+    audio_registry,
+    vlm_registry,
+    llm_registry,
+)
+
+# Every family union, so the reverse direction can confirm a registered loader
+# binds to a class that some family actually exposes.
+_ALL_UNION_MEMBERS: set[type[BaseModel]] = (
+    _union_members(DetectionArchitecture)
+    | _union_members(TrackingArchitecture)
+    | _union_members(AudioArchitecture)
+    | _union_members(VLMArchitecture)
+    | _union_members(LLMArchitecture)
+)
+
+
+def _iter_catalog_options() -> list[tuple[str, str, str, str, str]]:
+    """Yield one record per model option across both shipped catalogs.
+
+    Returns:
+        A list of ``(catalog_name, task_name, option_name, kind, framework)``
+        tuples covering every option in both catalog files. Parsing mirrors the
+        application: the same discriminated ``Architecture`` adapter that
+        :class:`ModelConfig` uses validates each ``architecture`` block, so an
+        unknown ``kind`` or a malformed block fails here exactly as it would at
+        config load.
+    """
+    records: list[tuple[str, str, str, str, str]] = []
+    for catalog_path in _CATALOG_PATHS:
+        catalog = yaml.safe_load(catalog_path.read_text())
+        for task_name, task in catalog["models"].items():
+            for option_name, option in task.get("options", {}).items():
+                # Validate through the same adapter the app uses; this both
+                # parses the kind and rejects unknown or malformed blocks.
+                parsed: Architecture = _ARCHITECTURE_ADAPTER.validate_python(option["architecture"])
+                kind = str(parsed.kind)  # type: ignore[attr-defined]
+                framework = str(option["framework"])
+                records.append((catalog_path.name, task_name, option_name, kind, framework))
+    return records
+
+
+_CATALOG_OPTIONS = _iter_catalog_options()
+
+
+def test_catalogs_contain_options() -> None:
+    """The catalogs are non-empty so the parametrized checks are meaningful."""
+    assert _CATALOG_OPTIONS, "no catalog options were discovered; check config paths"
+
+
+@pytest.mark.parametrize(
+    ("catalog_name", "task_name", "option_name", "kind", "framework"),
+    _CATALOG_OPTIONS,
+    ids=[f"{c}:{t}:{o}" for c, t, o, _k, _f in _CATALOG_OPTIONS],
+)
+def test_every_catalog_option_is_dispatchable(
+    catalog_name: str,
+    task_name: str,
+    option_name: str,
+    kind: str,
+    framework: str,
+) -> None:
+    """Every catalog option resolves to a registered loader or a documented path.
+
+    This is the forward direction. An option is dispatchable when it matches one
+    of the documented dispatch paths:
+
+    1. its framework is a pre-dispatch framework (external_api or sam3),
+    2. its task section is built by a dedicated task factory (diarization, vad),
+       or
+    3. its architecture is registered in the registry that owns its task
+       section.
+
+    Any option that satisfies none of these would fail at load time; failing it
+    here keeps the catalog and the dispatch wiring in lockstep.
+    """
+    if framework in _PREDISPATCH_FRAMEWORKS:
+        return
+    if task_name in _DEDICATED_FACTORY_TASKS:
+        return
+
+    assert task_name in _TASK_DISPATCH, (
+        f"{catalog_name}:{task_name}:{option_name} carries architecture-keyed "
+        f"framework {framework!r} but {task_name!r} has no registry mapping in "
+        "this test; add it to _TASK_DISPATCH or document a new pre-dispatch path."
+    )
+
+    kind_to_class, registries = _TASK_DISPATCH[task_name]
+    assert kind in kind_to_class, (
+        f"{catalog_name}:{task_name}:{option_name} declares kind {kind!r}, which "
+        f"is not a member of the {task_name!r} architecture family."
+    )
+    architecture_cls = kind_to_class[kind]
+    registered = any(
+        architecture_cls in registry.registered_architectures for registry in registries
+    )
+    assert registered, (
+        f"{catalog_name}:{task_name}:{option_name} declares architecture "
+        f"{architecture_cls.__name__} (kind {kind!r}, framework {framework!r}) but no "
+        f"loader is registered for it in {[r.family for r in registries]!r} and it is "
+        "not a documented framework pre-dispatch. Either register a loader or add a "
+        "pre-dispatch branch in the task factory."
+    )
+
+
+@pytest.mark.parametrize(
+    "registry",
+    _ALL_REGISTRIES,
+    ids=[registry.family for registry in _ALL_REGISTRIES],
+)
+def test_every_registered_loader_targets_a_union_member(registry: _RegistryView) -> None:
+    """Every registered architecture is a member of some family union.
+
+    This is the reverse direction. A loader may legitimately register for an
+    architecture that no catalog currently selects (for example GLM4 is in
+    ``llm_registry`` without appearing in either catalog), so this does not
+    require catalog presence. It only requires that the architecture is a real
+    member of a family union, which guarantees a catalog COULD reach it through
+    the normal discriminated-union schema.
+    """
+    for architecture_cls in registry.registered_architectures:
+        assert architecture_cls in _ALL_UNION_MEMBERS, (
+            f"{registry.family} registers a loader for {architecture_cls.__name__}, which "
+            "is not a member of any architecture family union. A loader must target an "
+            "architecture the catalog schema can express."
+        )
+
+
+# The SAM 3.1 architectures are catalog-reachable only through the
+# framework-level pre-dispatch the catalog sweep above trusts when it returns
+# early on ``framework == "sam3"``. The two tests below prove that branch
+# actually exists in both task factories, so that early return is grounded in
+# real wiring rather than an assumption. The sam3 package is mocked in
+# ``sys.modules`` so neither factory imports the heavy dependency or loads a
+# model; the factories operate on mocks only.
+
+
+def _sam3_model_config(framework_label: str) -> ModelConfig:
+    """Build the application ``ModelConfig`` a SAM 3.1 catalog option produces.
+
+    The application-layer ``ModelConfig`` is what the catalog loader hands the
+    task factories at runtime, so constructing it from the same dict shape a
+    ``models.yaml`` SAM 3.1 entry uses exercises the real dispatch path.
+
+    Args:
+        framework_label: The SAM 3.1 framework hint, always ``"sam3"``.
+
+    Returns:
+        A ``ModelConfig`` whose architecture is the SAM 3.1 detection family,
+        used only to exercise the framework pre-dispatch branch (the
+        architecture instance is never consulted on that branch).
+    """
+    return ModelConfig(
+        {
+            "model_id": "facebook/sam3.1-base",
+            "framework": framework_label,
+            "architecture": {"kind": "sam-3-1-detection"},
+            "vram_gb": 0,
+            "cpu_memory_gb": 0.0,
+            "cpu_compatible": True,
+            "speed": "fast",
+            "description": "",
+        }
+    )
+
+
+def test_object_detection_factory_predispatches_sam3() -> None:
+    """``object_detection`` builds the SAM 3.1 detection adapter for framework sam3.
+
+    This is the regression guard for the previously un-wired detection path: a
+    ``framework: "sam3"`` detection option must reach ``SAM3DetectionAdapter``
+    before the architecture-keyed detection registry (which has no SAM 3.1
+    loader) is consulted.
+    """
+    from src.infrastructure.config.task_factories import build_default_task_factories
+
+    sam3_loader = MagicMock()
+    loader_cls = MagicMock(return_value=sam3_loader)
+    adapter = MagicMock()
+    adapter_cls = MagicMock(return_value=adapter)
+    with patch.dict(
+        "sys.modules",
+        {
+            "src.infrastructure.adapters.outbound.models.sam3": MagicMock(
+                SAM3Loader=loader_cls,
+                SAM3DetectionAdapter=adapter_cls,
+            )
+        },
+    ):
+        factory = build_default_task_factories()["object_detection"]
+        returned = factory(_sam3_model_config("sam3"))
+
+    assert returned is adapter
+    loader_cls.assert_called_once()
+    adapter_cls.assert_called_once_with(sam3_loader)
+    sam3_loader.load.assert_called_once()
+
+
+def test_object_tracking_factory_predispatches_sam3() -> None:
+    """``object_tracking`` builds the SAM 3.1 tracking adapter for framework sam3.
+
+    The tracking side of the same pre-dispatch invariant, so both SAM 3.1
+    architectures the catalog ships remain reachable.
+    """
+    from src.infrastructure.config.task_factories import build_default_task_factories
+
+    sam3_loader = MagicMock()
+    loader_cls = MagicMock(return_value=sam3_loader)
+    adapter = MagicMock()
+    adapter_cls = MagicMock(return_value=adapter)
+    with patch.dict(
+        "sys.modules",
+        {
+            "src.infrastructure.adapters.outbound.models.sam3": MagicMock(
+                SAM3Loader=loader_cls,
+                SAM3TrackingAdapter=adapter_cls,
+            )
+        },
+    ):
+        factory = build_default_task_factories()["object_tracking"]
+        returned = factory(_sam3_model_config("sam3"))
+
+    assert returned is adapter
+    loader_cls.assert_called_once()
+    adapter_cls.assert_called_once_with(sam3_loader)
+    sam3_loader.load.assert_called_once()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fovea",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "FOVEA - Flexible Ontology Visual Event Analyzer",
   "scripts": {
     "dev": "pnpm run dev:infra && pnpm run dev:services",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,24 +329,15 @@ importers:
       camelcase-keys:
         specifier: ^10.0.1
         version: 10.0.2
-      cors:
-        specifier: ^2.8.5
-        version: 2.8.6
       dotenv:
         specifier: ^17.2.3
         version: 17.3.1
-      express:
-        specifier: ^4.18.2
-        version: 4.22.1
       fastify:
         specifier: ^5.6.1
         version: 5.8.2
       ioredis:
         specifier: 5.9.3
         version: 5.9.3
-      multer:
-        specifier: ^1.4.5-lts.1
-        version: 1.4.5-lts.2
       pino-pretty:
         specifier: ^13.1.1
         version: 13.1.3
@@ -363,15 +354,6 @@ importers:
         specifier: ^4.1.11
         version: 4.3.6
     devDependencies:
-      '@types/cors':
-        specifier: ^2.8.17
-        version: 2.8.19
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.25
-      '@types/multer':
-        specifier: ^1.4.11
-        version: 1.4.13
       '@types/node':
         specifier: ^20.11.19
         version: 20.19.37
@@ -2851,9 +2833,6 @@ packages:
   '@types/bcrypt@6.0.0':
     resolution: {integrity: sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==}
 
-  '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
-
   '@types/bunyan@1.8.11':
     resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
 
@@ -2866,29 +2845,17 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
-  '@types/cors@2.8.19':
-    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/express-serve-static-core@4.19.8':
-    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
-
-  '@types/express@4.17.25':
-    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
-
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/junit-report-builder@3.0.2':
     resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
@@ -2904,12 +2871,6 @@ packages:
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
-
-  '@types/mime@1.3.5':
-    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/multer@1.4.13':
-    resolution: {integrity: sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==}
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
@@ -2929,12 +2890,6 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/qs@6.15.0':
-    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
-
-  '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -2942,15 +2897,6 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
-
-  '@types/send@0.17.6':
-    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
-
-  '@types/send@1.2.1':
-    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
-
-  '@types/serve-static@1.15.10':
-    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
@@ -3118,10 +3064,6 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
-  accepts@1.3.8:
-    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
-    engines: {node: '>= 0.6'}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3198,9 +3140,6 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  append-field@1.0.0:
-    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -3214,9 +3153,6 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
-
-  array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -3293,10 +3229,6 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -3323,19 +3255,12 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
   bullmq@5.70.4:
     resolution: {integrity: sha512-S58YT/tGdhc4pEPcIahtZRBR1TcTLpss1UKiXimF+Vy4yZwF38pW2IvhHqs4j4dEbZqDt8oi0jGGN/WYQHbPDg==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3483,20 +3408,12 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concat-stream@1.6.2:
-    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
-    engines: {'0': node >= 0.8}
-
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -3508,9 +3425,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-signature@1.0.7:
-    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -3526,9 +3440,6 @@ packages:
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-
-  core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -3591,14 +3502,6 @@ packages:
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
-
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3668,10 +3571,6 @@ packages:
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
-
-  destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -3899,10 +3798,6 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
-  express@4.22.1:
-    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
-    engines: {node: '>= 0.10.0'}
-
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -3995,10 +3890,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@1.3.2:
-    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
-    engines: {node: '>= 0.8'}
-
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -4048,10 +3939,6 @@ packages:
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -4249,10 +4136,6 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
-  iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -4398,9 +4281,6 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
-
-  isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4715,16 +4595,9 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
-
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
-
-  merge-descriptors@1.0.3:
-    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -4760,11 +4633,6 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
-
-  mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -4813,10 +4681,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
   mnemonist@0.40.0:
     resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
 
@@ -4830,9 +4694,6 @@ packages:
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4853,11 +4714,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  multer@1.4.5-lts.2:
-    resolution: {integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==}
-    engines: {node: '>= 6.0.0'}
-    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -4883,10 +4739,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  negotiator@0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -5078,9 +4930,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -5212,9 +5061,6 @@ packages:
       typescript:
         optional: true
 
-  process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -5258,10 +5104,6 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
@@ -5283,10 +5125,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  raw-body@2.5.3:
-    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
-    engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -5366,9 +5204,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
-
-  readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -5474,12 +5309,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   safe-regex2@5.0.0:
     resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
 
@@ -5509,17 +5338,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.19.2:
-    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
-    engines: {node: '>= 0.8.0'}
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
-
-  serve-static@1.16.3:
-    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
-    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -5622,10 +5443,6 @@ packages:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
 
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -5640,9 +5457,6 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -5866,16 +5680,9 @@ packages:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
 
-  type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
-
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
-
-  typedarray@0.0.6:
-    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typedoc-plugin-markdown@4.10.0:
     resolution: {integrity: sha512-psrg8Rtnv4HPWCsoxId+MzEN8TVK5jeKCnTbnGAbTBqcDapR9hM41bJT/9eAyKn9C2MDG9Qjh3MkltAYuLDoXg==}
@@ -5952,10 +5759,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -9184,11 +8987,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@types/body-parser@1.19.6':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 20.19.37
-
   '@types/bunyan@1.8.11':
     dependencies:
       '@types/node': 20.19.37
@@ -9204,35 +9002,15 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
-  '@types/cors@2.8.19':
-    dependencies:
-      '@types/node': 20.19.37
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/express-serve-static-core@4.19.8':
-    dependencies:
-      '@types/node': 20.19.37
-      '@types/qs': 6.15.0
-      '@types/range-parser': 1.2.7
-      '@types/send': 1.2.1
-
-  '@types/express@4.17.25':
-    dependencies:
-      '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 4.19.8
-      '@types/qs': 6.15.0
-      '@types/serve-static': 1.15.10
 
   '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/http-errors@2.0.5': {}
 
   '@types/junit-report-builder@3.0.2': {}
 
@@ -9247,12 +9025,6 @@ snapshots:
       '@types/node': 20.19.37
 
   '@types/methods@1.1.4': {}
-
-  '@types/mime@1.3.5': {}
-
-  '@types/multer@1.4.13':
-    dependencies:
-      '@types/express': 4.17.25
 
   '@types/mysql@2.15.27':
     dependencies:
@@ -9278,10 +9050,6 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/qs@6.15.0': {}
-
-  '@types/range-parser@1.2.7': {}
-
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -9290,21 +9058,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
-
-  '@types/send@0.17.6':
-    dependencies:
-      '@types/mime': 1.3.5
-      '@types/node': 20.19.37
-
-  '@types/send@1.2.1':
-    dependencies:
-      '@types/node': 20.19.37
-
-  '@types/serve-static@1.15.10':
-    dependencies:
-      '@types/http-errors': 2.0.5
-      '@types/node': 20.19.37
-      '@types/send': 0.17.6
 
   '@types/statuses@2.0.6': {}
 
@@ -9542,11 +9295,6 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
-  accepts@1.3.8:
-    dependencies:
-      mime-types: 2.1.35
-      negotiator: 0.6.3
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -9612,8 +9360,6 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  append-field@1.0.0: {}
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -9625,8 +9371,6 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
-
-  array-flatten@1.1.1: {}
 
   array-union@2.1.0: {}
 
@@ -9699,23 +9443,6 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  body-parser@1.20.4:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.14.2
-      raw-body: 2.5.3
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -9757,8 +9484,6 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  buffer-from@1.1.2: {}
-
   bullmq@5.70.4:
     dependencies:
       cron-parser: 4.9.0
@@ -9774,10 +9499,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
 
   bytes@3.1.2: {}
 
@@ -9926,28 +9647,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  concat-stream@1.6.2:
-    dependencies:
-      buffer-from: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      typedarray: 0.0.6
-
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
-
-  content-disposition@0.5.4:
-    dependencies:
-      safe-buffer: 5.2.1
 
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
 
@@ -9956,8 +9664,6 @@ snapshots:
   cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
-
-  core-util-is@1.0.3: {}
 
   cors@2.8.6:
     dependencies:
@@ -10025,10 +9731,6 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -10065,8 +9767,6 @@ snapshots:
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
-
-  destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -10356,42 +10056,6 @@ snapshots:
       express: 5.2.1
       ip-address: 10.1.0
 
-  express@4.22.1:
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.4
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.0.7
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.3.2
-      fresh: 0.5.2
-      http-errors: 2.0.1
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.12
-      proxy-addr: 2.0.7
-      qs: 6.14.2
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -10526,18 +10190,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.2:
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -10596,8 +10248,6 @@ snapshots:
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
-
-  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -10810,10 +10460,6 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -10931,8 +10577,6 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
-
-  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -11252,11 +10896,7 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  media-typer@0.3.0: {}
-
   media-typer@1.1.0: {}
-
-  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -11282,8 +10922,6 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
-
-  mime@1.6.0: {}
 
   mime@2.6.0: {}
 
@@ -11319,10 +10957,6 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-
   mnemonist@0.40.0:
     dependencies:
       obliterator: 2.0.5
@@ -11337,8 +10971,6 @@ snapshots:
       global: 4.4.0
 
   mrmime@2.0.1: {}
-
-  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -11383,16 +11015,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  multer@1.4.5-lts.2:
-    dependencies:
-      append-field: 1.0.0
-      busboy: 1.6.0
-      concat-stream: 1.6.2
-      mkdirp: 0.5.6
-      object-assign: 4.1.1
-      type-is: 1.6.18
-      xtend: 4.0.2
-
   mustache@4.2.0: {}
 
   mute-stream@2.0.0: {}
@@ -11407,8 +11029,6 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
-
-  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -11583,8 +11203,6 @@ snapshots:
       lru-cache: 11.2.6
       minipass: 7.1.3
 
-  path-to-regexp@0.1.12: {}
-
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.3.0: {}
@@ -11719,8 +11337,6 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  process-nextick-args@2.0.1: {}
-
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
@@ -11780,10 +11396,6 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
@@ -11797,13 +11409,6 @@ snapshots:
   quick-lru@7.3.0: {}
 
   range-parser@1.2.1: {}
-
-  raw-body@2.5.3:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -11881,16 +11486,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -12020,10 +11615,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.1.2: {}
-
-  safe-buffer@5.2.1: {}
-
   safe-regex2@5.0.0:
     dependencies:
       ret: 0.5.0
@@ -12046,24 +11637,6 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@0.19.2:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.1
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -12077,15 +11650,6 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@1.16.3:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12227,8 +11791,6 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  streamsearch@1.1.0: {}
-
   strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
@@ -12248,10 +11810,6 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
 
   stringify-object@5.0.0:
     dependencies:
@@ -12451,18 +12009,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  type-is@1.6.18:
-    dependencies:
-      media-typer: 0.3.0
-      mime-types: 2.1.35
-
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
-
-  typedarray@0.0.6: {}
 
   typedoc-plugin-markdown@4.10.0(typedoc@0.28.17(typescript@5.9.3)):
     dependencies:
@@ -12521,8 +12072,6 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
-
-  utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fovea/server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -46,12 +46,9 @@
     "bcrypt": "^6.0.0",
     "bullmq": "^5.59.0",
     "camelcase-keys": "^10.0.1",
-    "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^4.18.2",
     "fastify": "^5.6.1",
     "ioredis": "^5.8.0",
-    "multer": "^1.4.5-lts.1",
     "pino-pretty": "^13.1.1",
     "prisma": "^6.16.3",
     "snakecase-keys": "^9.0.2",
@@ -59,9 +56,6 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.21",
-    "@types/multer": "^1.4.11",
     "@types/node": "^20.11.19",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^7.0.2",

--- a/wikibase/pyproject.toml
+++ b/wikibase/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fovea-wikibase-loader"
-version = "0.4.0"
+version = "0.4.4"
 description = "Data loader for importing Wikidata into local Wikibase instances"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Description

Phase 0 of the architecture-modularization roadmap (`notes/architecture-review.md`): reversible cleanups with **no user-facing behavior change**. This is the standalone `0.4.4` patch that precedes the `0.5.0` cycle (Phases 1–4). It removes confirmed dead dependencies, closes one latent model-loader gap with a regression guard, de-duplicates a configuration template, and brings two drifted manifests back onto the release line.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

<!-- Link related issues using GitHub's syntax (e.g., "Fixes #123", "Relates to #456") -->

No tracking issue — this is roadmap-driven work from `notes/architecture-review.md` (Phase 0).

## Changes Made

<!-- Provide a detailed list of changes -->

- Removed the unused `cors`, `express`, and `multer` runtime dependencies and their `@types/cors` / `@types/express` / `@types/multer` type packages from `server/package.json`; the backend is entirely Fastify (`@fastify/cors`) and these had zero import sites in `server/src`. Regenerated `pnpm-lock.yaml` (451 lines removed, 0 added).
- Wired the missing `framework == "sam3"` pre-dispatch into `_object_detection_factory` (`model-service/src/infrastructure/config/task_factories.py`) so a SAM 3.1 object-detection config resolves to the existing, contract-tested `SAM3DetectionAdapter` instead of falling through to the architecture-keyed detection registry (which has no SAM3 loader) and raising `UnknownArchitectureError` at load. This mirrors the pre-dispatch the tracking factory already had. Nothing was deleted — the `SAM3Detection`/`SAM3Tracking` classes are load-bearing for YAML schema validity.
- Added `model-service/test/config/test_catalog_dispatch_invariant.py`, a bidirectional architecture-to-loader invariant test (forward: every catalog `architecture.kind` resolves to a registered loader, a documented framework pre-dispatch, or a dedicated task factory; reverse: every registered loader targets a valid architecture-family union member). Reverting the SAM3 fix makes it fail.
- De-duplicated the `REDIS_PORT` key in `.env.example` (it was declared in both the Redis-configuration and host-ports sections).
- Synced `model-service/package.json` and `wikibase/pyproject.toml` (both still at `0.4.0`) onto the release line; bumped all seven package manifests to `0.4.4` and added the `## [0.4.4]` entry to `CHANGELOG.md` and its `docs/docs/project/changelog.md` mirror.

> Local-only housekeeping done outside the PR (gitignored/untracked, so not in the diff): deleted the byte-identical `.env.local-backup`, de-duplicated five repeated keys in the live `.env` (behavior-preserving — removed placeholder first-occurrences, kept real values), and removed the empty root `test/` and the untracked vestigial `.husky/` (no `prepare` script, not a devDependency).

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Environment

- OS: macOS (Darwin 24.6.0)
- Browser (if applicable): N/A
- Node version: 22
- Python version (if applicable): 3.12

### Test Cases

<!-- List the test cases you verified -->

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

<!-- Provide step-by-step instructions for reviewers to test your changes -->

1. `pnpm install --frozen-lockfile` succeeds against the regenerated lockfile.
2. `pnpm --filter @fovea/server lint && pnpm --filter @fovea/server exec tsc --noEmit && pnpm --filter @fovea/server build` all pass with the three dependencies removed.
3. In `model-service/`: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src/` all pass, and `uv run pytest -m "not requires_models" test/config/test_catalog_dispatch_invariant.py --override-ini="addopts=" -q` passes. Reverting the `_object_detection_factory` change makes the invariant test fail with `UnknownArchitectureError`.

## Screenshots/Videos

N/A — no UI changes.

## Documentation

<!-- Check all that apply -->

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

<!-- Describe any performance implications of your changes -->

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: Removing unused dependencies trims the backend install; no runtime path changed except adding a fast `framework` string check at detection-factory dispatch.

## Breaking Changes

<!-- If this PR includes breaking changes, list them here with migration instructions -->

**Breaking changes:**
- None.

**Migration guide:**
- N/A.

## Checklist

<!-- Ensure all items are completed before requesting review -->

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The architecture review's SAM3 "dead code" finding was inaccurate and has been corrected in the working copy of `notes/architecture-review.md`: the classes are intentional, and the real gap was the asymmetric detection/tracking pre-dispatch, now fixed.

## Reviewer Guidance

<!-- Optional: Provide specific guidance for reviewers -->

The highest-signal file is `model-service/src/infrastructure/config/task_factories.py` — confirm the new SAM3 detection branch matches the existing tracking branch. The lockfile diff is large but purely deletions of the three removed packages plus their transitive deps.
