### PR TITLE
refactor: backend configuration single-source-of-truth (Phase 1a, opens 0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-17
+
+The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/architecture-review.md`): single sources of truth for configuration, containerization, the build/test surface, and cross-service contracts. Changes land incrementally on `release/0.5.x`; this section accumulates them.
+
+### Changed
+
+#### Backend Configuration Single-Source-of-Truth
+
+- All backend environment access is centralized in one typed, validated module, `server/src/config.ts`. It is the only file in `server/src` permitted to read `process.env` (enforced by a new ESLint `no-restricted-syntax` rule with a `config.ts`/`prisma`/`test` exemption), loads an optional local `.env` via `dotenv`, exposes a deep-frozen `config` object grouped by concern (`server`, `redis`, `auth`, `storage`, `modelService`, `rateLimit`, `cors`, `otel`, `mode`, `demo`, `tours`, `wikidata`, `externalLinks`, `defaultUser`), and centralizes every default and coercion. All 31 previously-scattered `process.env` reads across routes, services, queues, middleware, and libs now go through it. The two dynamic read patterns are exposed as typed helpers: `config.modelService.timeoutMs(endpoint)` and `config.getProviderApiKey(provider)`.
+- Configuration is now validated once at startup and fails fast: `config.ts` is imported first in `server/src/index.ts` (before tracing), validates numeric env vars through a TypeBox schema, requires `API_KEY_ENCRYPTION_KEY` to hex-decode to 32 bytes at boot (previously validated lazily at first key use), and refuses an unset or dev-default `SESSION_SECRET` in production.
+- Four environment defaults that previously disagreed across read sites are unified to one value each: `STORAGE_PATH` (the repo-relative `videos` path), `FOVEA_MODE` (`multi-user`), `MODEL_SERVICE_URL` (`http://localhost:8000`), and `OTEL_EXPORTER_OTLP_ENDPOINT` (`http://localhost:4318`). These defaults only apply when the variable is unset; every docker/production deployment sets them explicitly, so deployed behavior is unchanged. Single-user and demo-mode branching now route through the single `isSingleUserMode()` / `isDemoModeEnabled()` predicates (reading from `config`) instead of inline per-handler `process.env` comparisons.
+
 ## [0.4.4] - 2026-06-17
 
 The first installment of the architecture-modularization roadmap (`notes/architecture-review.md`, Phase 0): reversible cleanups with no user-facing behavior change — dead dependencies removed, a configuration template de-duplicated, and one latent model-loader gap closed with a regression guard.

--- a/annotation-tool/package.json
+++ b/annotation-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fovea/annotation-tool",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -11,6 +11,18 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-17
+
+The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/architecture-review.md`): single sources of truth for configuration, containerization, the build/test surface, and cross-service contracts. Changes land incrementally on `release/0.5.x`; this section accumulates them.
+
+### Changed
+
+#### Backend Configuration Single-Source-of-Truth
+
+- All backend environment access is centralized in one typed, validated module, `server/src/config.ts`. It is the only file in `server/src` permitted to read `process.env` (enforced by a new ESLint `no-restricted-syntax` rule with a `config.ts`/`prisma`/`test` exemption), loads an optional local `.env` via `dotenv`, exposes a deep-frozen `config` object grouped by concern (`server`, `redis`, `auth`, `storage`, `modelService`, `rateLimit`, `cors`, `otel`, `mode`, `demo`, `tours`, `wikidata`, `externalLinks`, `defaultUser`), and centralizes every default and coercion. All 31 previously-scattered `process.env` reads across routes, services, queues, middleware, and libs now go through it. The two dynamic read patterns are exposed as typed helpers: `config.modelService.timeoutMs(endpoint)` and `config.getProviderApiKey(provider)`.
+- Configuration is now validated once at startup and fails fast: `config.ts` is imported first in `server/src/index.ts` (before tracing), validates numeric env vars through a TypeBox schema, requires `API_KEY_ENCRYPTION_KEY` to hex-decode to 32 bytes at boot (previously validated lazily at first key use), and refuses an unset or dev-default `SESSION_SECRET` in production.
+- Four environment defaults that previously disagreed across read sites are unified to one value each: `STORAGE_PATH` (the repo-relative `videos` path), `FOVEA_MODE` (`multi-user`), `MODEL_SERVICE_URL` (`http://localhost:8000`), and `OTEL_EXPORTER_OTLP_ENDPOINT` (`http://localhost:4318`). These defaults only apply when the variable is unset; every docker/production deployment sets them explicitly, so deployed behavior is unchanged. Single-user and demo-mode branching now route through the single `isSingleUserMode()` / `isDemoModeEnabled()` predicates (reading from `config`) instead of inline per-handler `process.env` comparisons.
+
 ## [0.4.4] - 2026-06-17
 
 The first installment of the architecture-modularization roadmap (`notes/architecture-review.md`, Phase 0): reversible cleanups with no user-facing behavior change — dead dependencies removed, a configuration template de-duplicated, and one latent model-loader gap closed with a regression guard.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/model-service/package.json
+++ b/model-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fovea-model-service",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "AI model inference service for video annotation",
   "scripts": {
     "dev": "source venv/bin/activate && uvicorn src.main:app --reload --host 0.0.0.0 --port 8000",

--- a/model-service/pyproject.toml
+++ b/model-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fovea-model-service"
-version = "0.4.4"
+version = "0.5.0"
 description = "Model service for fovea video annotation tool"
 requires-python = ">=3.12"
 dependencies = [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fovea",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "FOVEA - Flexible Ontology Visual Event Analyzer",
   "scripts": {
     "dev": "pnpm run dev:infra && pnpm run dev:services",

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -28,6 +28,13 @@
           }
         ]
       }
+    ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "MemberExpression[object.name='process'][property.name='env']",
+        "message": "Read environment variables only via src/config.ts. Add the value to the typed config module and import `config` instead of reading process.env directly."
+      }
     ]
   },
   "overrides": [
@@ -36,8 +43,19 @@
       "rules": { "no-restricted-imports": "off" }
     },
     {
+      "files": ["src/config.ts"],
+      "rules": { "no-restricted-syntax": "off" }
+    },
+    {
+      "files": ["prisma/**/*"],
+      "rules": { "no-restricted-syntax": "off" }
+    },
+    {
       "files": ["test/**/*"],
-      "rules": { "no-restricted-imports": "off" }
+      "rules": {
+        "no-restricted-imports": "off",
+        "no-restricted-syntax": "off"
+      }
     }
   ],
   "ignorePatterns": ["dist", "node_modules", "coverage"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fovea/server",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter'
 import { FastifyAdapter } from '@bull-board/fastify'
 import { videoSummarizationQueue, claimExtractionQueue, closeQueues } from './queues/setup.js'
 import { apiRequestCounter, apiRequestDuration } from './metrics.js'
+import { config } from './config.js'
 import { prisma } from './lib/prisma.js'
 import { AppError, TooManyRequestsError } from './lib/errors.js'
 import { recordApiError } from './lib/errorMetrics.js'
@@ -40,8 +41,8 @@ export async function buildApp() {
   const app = Fastify({
     trustProxy: true,
     logger: {
-      level: process.env.LOG_LEVEL || 'info',
-      transport: process.env.NODE_ENV !== 'production' ? {
+      level: config.server.logLevel,
+      transport: !config.server.isProduction ? {
         target: 'pino-pretty',
         options: {
           colorize: true,
@@ -70,12 +71,10 @@ export async function buildApp() {
   // their corpus: a deployment with many videos x personas fans a hard refresh
   // out into hundreds of per-persona / per-video requests, which trips a cap
   // sized for a small instance. Defaults match the historical 1000 / 1 minute.
-  if (process.env.NODE_ENV !== 'test') {
-    const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 1000
-    const rateLimitWindow = process.env.RATE_LIMIT_WINDOW || '1 minute'
+  if (!config.server.isTest) {
     await app.register(fastifyRateLimit, {
-      max: rateLimitMax,
-      timeWindow: rateLimitWindow,
+      max: config.rateLimit.max,
+      timeWindow: config.rateLimit.window,
       keyGenerator: (request) => {
         return request.ip
       }
@@ -86,18 +85,13 @@ export async function buildApp() {
   // Include both localhost and 127.0.0.1 to handle browser differences
   // Some browsers treat localhost and 127.0.0.1 as different origins
   await app.register(fastifyCors, {
-    origin: process.env.ALLOWED_ORIGINS?.split(',') || [
-      'http://localhost:5173',
-      'http://localhost:3000',
-      'http://127.0.0.1:5173',
-      'http://127.0.0.1:3000'
-    ],
+    origin: config.cors.allowedOrigins,
     credentials: true
   })
 
   // Cookie support for session management
   await app.register(fastifyCookie, {
-    secret: process.env.SESSION_SECRET || 'dev-secret-change-in-production',
+    secret: config.auth.sessionSecret,
   })
 
   // OpenAPI documentation

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,540 @@
+/**
+ * Single source of truth for every environment-derived setting.
+ *
+ * This is the ONLY file in `server/src` permitted to read `process.env`.
+ * An ESLint `no-restricted-syntax` rule bans `process.env` everywhere
+ * else and points offenders here. Every default, every type coercion,
+ * and every required-value check lives in this module so a reader can
+ * answer "what does this deployment do when X is unset?" by looking in
+ * exactly one place.
+ *
+ * Shape:
+ *   - `config` is a deep-frozen object grouped into nested namespaces by
+ *     concern (server, db, redis, auth, storage, modelService, ...).
+ *   - Leaf values are exposed as lazy getters or typed helper functions
+ *     that re-read `process.env` at access time. This preserves the exact
+ *     lazy `process.env.X || default` semantics the codebase relied on
+ *     before centralization, so a handler that reads `config.mode.current`
+ *     inside a request sees the same value the old inline read saw.
+ *   - Coercions (integers, booleans, comma-split lists) are validated
+ *     against a TypeBox schema and the raw env is validated eagerly at
+ *     module load so an invalid integer fails fast at startup rather than
+ *     surfacing as a `NaN` deep in a handler.
+ *
+ * Fail-fast: importing this module runs `assertStartupConfig()`, which
+ * validates the typed env surface and the required
+ * `API_KEY_ENCRYPTION_KEY`, and (in production) refuses an unset or
+ * dev-default `SESSION_SECRET`. Import this module FIRST in `index.ts`,
+ * before `./tracing.js`, so validation throws before any subsystem
+ * (OTEL, Fastify, Prisma) initializes.
+ *
+ * Default unifications applied here (the only intentional behavior
+ * change versus the pre-centralization code; every real docker/prod
+ * deployment sets these via env, so the default only fires in local
+ * dev where the localhost form is correct):
+ *   1. STORAGE_PATH default resolves to `<repo>/videos` (the index.ts
+ *      computed form), replacing the inconsistent `/videos` literals in
+ *      videoStorage.ts and routes/videos/index.ts.
+ *   2. FOVEA_MODE default is `multi-user` (the secure default used by 8
+ *      of 10 sites), replacing the `single-user` default in
+ *      routes/config.ts and routes/auth.ts.
+ *   3. MODEL_SERVICE_URL default is `http://localhost:8000` (7 sites),
+ *      replacing the `http://model-service:8000` default in
+ *      routes/models.ts and services/system-config-propagator.ts.
+ *   4. OTEL_EXPORTER_OTLP_ENDPOINT default is `http://localhost:4318`
+ *      (tracing.ts), replacing the `http://otel-collector:4318` default
+ *      in routes/telemetry.ts.
+ *
+ * @module
+ */
+
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { Type, type Static } from '@sinclair/typebox'
+import { Value } from '@sinclair/typebox/value'
+import dotenv from 'dotenv'
+
+// Optional local `.env` support. A no-op in docker/prod where no `.env`
+// file exists. Must run before any `process.env` read below.
+dotenv.config()
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// ---------------------------------------------------------------------------
+// Low-level coercion helpers (the only place env strings are parsed).
+// ---------------------------------------------------------------------------
+
+function readString(name: string): string | undefined {
+  const raw = process.env[name]
+  if (raw === undefined || raw === '') return undefined
+  return raw
+}
+
+function readStringWithDefault(name: string, fallback: string): string {
+  return readString(name) ?? fallback
+}
+
+function readInt(name: string, fallback: number): number {
+  const raw = readString(name)
+  if (raw === undefined) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+/** True only when the env var equals the literal string `'true'`. */
+function readBooleanStrictTrue(name: string): boolean {
+  return process.env[name] === 'true'
+}
+
+/** True when the env var is `'true'` or `'1'` (the demo-flag idiom). */
+function readBooleanTrueOrOne(name: string): boolean {
+  const raw = process.env[name]
+  return raw === 'true' || raw === '1'
+}
+
+/** True unless the env var is explicitly `'false'` (default-on switch). */
+function readBooleanDefaultTrue(name: string): boolean {
+  return process.env[name] !== 'false'
+}
+
+// ---------------------------------------------------------------------------
+// Default constants. Centralized so every consumer shares one literal.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STORAGE_PATH = join(dirname(__dirname), '..', 'videos')
+const DEFAULT_MODE = 'multi-user'
+const DEFAULT_MODEL_SERVICE_URL = 'http://localhost:8000'
+const DEFAULT_OTEL_ENDPOINT = 'http://localhost:4318'
+const DEV_SESSION_SECRET = 'dev-secret-change-in-production'
+
+/** The four localhost origins allowed by default when ALLOWED_ORIGINS is
+ * unset. Copied verbatim from the historical inline default. Includes both
+ * `localhost` and `127.0.0.1` because some browsers treat them as distinct
+ * origins. */
+const DEFAULT_ALLOWED_ORIGINS: readonly string[] = [
+  'http://localhost:5173',
+  'http://localhost:3000',
+  'http://127.0.0.1:5173',
+  'http://127.0.0.1:3000',
+] as const
+
+const ENCRYPTION_KEY_BYTES = 32
+
+/** Per-endpoint model-service timeout defaults (milliseconds). Each value
+ * is the upper bound the backend waits before aborting a forwarded request
+ * to the model-service and surfacing a 504. Defaults target a GPU-warm
+ * production deployment; CPU-cold first-load is materially slower, so
+ * deployments override via the matching `MODEL_SERVICE_TIMEOUT_<NAME>_MS`
+ * env var. */
+const MODEL_SERVICE_TIMEOUT_DEFAULTS = {
+  detection: { env: 'MODEL_SERVICE_TIMEOUT_DETECTION_MS', ms: 60_000 },
+  thumbnails: { env: 'MODEL_SERVICE_TIMEOUT_THUMBNAILS_MS', ms: 30_000 },
+  ontologyAugment: { env: 'MODEL_SERVICE_TIMEOUT_ONTOLOGY_AUGMENT_MS', ms: 60_000 },
+  summarize: { env: 'MODEL_SERVICE_TIMEOUT_SUMMARIZE_MS', ms: 300_000 },
+  extractClaims: { env: 'MODEL_SERVICE_TIMEOUT_EXTRACT_CLAIMS_MS', ms: 300_000 },
+  synthesize: { env: 'MODEL_SERVICE_TIMEOUT_SYNTHESIZE_MS', ms: 300_000 },
+  transcribe: { env: 'MODEL_SERVICE_TIMEOUT_TRANSCRIBE_MS', ms: 300_000 },
+} as const
+
+/** Names of the per-endpoint model-service timeouts. */
+export type ModelServiceTimeoutEndpoint = keyof typeof MODEL_SERVICE_TIMEOUT_DEFAULTS
+
+// ---------------------------------------------------------------------------
+// Eagerly-validated typed env surface (fail-fast on malformed coercions).
+// ---------------------------------------------------------------------------
+
+/** Schema for the env vars whose coercion can fail (integers). Validated
+ * once at startup so a non-numeric `PORT` or `REDIS_PORT` throws a clear
+ * error rather than yielding a `NaN` later. Strings that fall back to a
+ * default when unset do not need schema validation. */
+const NumericEnvSchema = Type.Object({
+  PORT: Type.Optional(Type.String({ pattern: '^[0-9]+$' })),
+  REDIS_PORT: Type.Optional(Type.String({ pattern: '^[0-9]+$' })),
+  SESSION_TIMEOUT_DAYS: Type.Optional(Type.String({ pattern: '^[0-9]+$' })),
+  SESSION_IDLE_TIMEOUT_MINUTES: Type.Optional(Type.String({ pattern: '^[0-9]+$' })),
+  RATE_LIMIT_MAX: Type.Optional(Type.String({ pattern: '^[0-9]+$' })),
+})
+
+type NumericEnv = Static<typeof NumericEnvSchema>
+
+function collectNumericEnv(): NumericEnv {
+  const out: Record<string, string> = {}
+  for (const key of [
+    'PORT',
+    'REDIS_PORT',
+    'SESSION_TIMEOUT_DAYS',
+    'SESSION_IDLE_TIMEOUT_MINUTES',
+    'RATE_LIMIT_MAX',
+  ]) {
+    const raw = process.env[key]
+    if (raw !== undefined && raw !== '') out[key] = raw
+  }
+  return out as NumericEnv
+}
+
+/**
+ * Resolve and validate the API key encryption key.
+ *
+ * Reads `API_KEY_ENCRYPTION_KEY`, hex-decodes it, and requires exactly 32
+ * bytes (AES-256). Throws a descriptive Error when unset or wrong length.
+ * Read at call time so callers always see the current env (the encryption
+ * tests mutate it between cases).
+ *
+ * @returns the 32-byte key buffer
+ * @throws {Error} when the key is unset or not 32 bytes after hex decode
+ *
+ * @example
+ * ```typescript
+ * const key = config.auth.encryptionKey()
+ * crypto.createCipheriv('aes-256-gcm', key, iv)
+ * ```
+ */
+function resolveEncryptionKey(): Buffer {
+  const key = process.env.API_KEY_ENCRYPTION_KEY
+  if (!key) {
+    throw new Error('API_KEY_ENCRYPTION_KEY environment variable not set')
+  }
+  const keyBuffer = Buffer.from(key, 'hex')
+  if (keyBuffer.length !== ENCRYPTION_KEY_BYTES) {
+    throw new Error(
+      `API_KEY_ENCRYPTION_KEY must be ${ENCRYPTION_KEY_BYTES} bytes (${ENCRYPTION_KEY_BYTES * 2} hex characters)`,
+    )
+  }
+  return keyBuffer
+}
+
+/**
+ * Validate the startup configuration, throwing on any fatal problem.
+ *
+ * Runs at module load. Checks performed:
+ *   - numeric env vars coerce cleanly (TypeBox `Value.Errors`)
+ *   - `API_KEY_ENCRYPTION_KEY` is set and hex-decodes to 32 bytes
+ *   - in production, `SESSION_SECRET` is set and is not the dev default
+ *
+ * @throws {Error} listing every offending key when validation fails
+ */
+function assertStartupConfig(): void {
+  const numericEnv = collectNumericEnv()
+  if (!Value.Check(NumericEnvSchema, numericEnv)) {
+    const problems = [...Value.Errors(NumericEnvSchema, numericEnv)].map(
+      (e) => `${e.path.replace(/^\//, '')}: ${e.message}`,
+    )
+    throw new Error(
+      `Invalid environment configuration:\n  ${problems.join('\n  ')}`,
+    )
+  }
+
+  // Required: API key encryption key (fail fast before any subsystem boots).
+  resolveEncryptionKey()
+
+  // Production guard: refuse an unset or dev-default session secret.
+  if (process.env.NODE_ENV === 'production') {
+    const secret = process.env.SESSION_SECRET
+    if (!secret || secret === DEV_SESSION_SECRET) {
+      throw new Error(
+        'SESSION_SECRET must be set to a non-default value in production',
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The frozen config object. Leaf values are getters/functions that re-read
+// env so runtime mutation (tests, hot-reconfigured deployments) is honored.
+// ---------------------------------------------------------------------------
+
+/** Coerce a model-service timeout env var to a positive integer, falling
+ * back to the endpoint default when unset or malformed. */
+function resolveTimeoutMs(endpoint: ModelServiceTimeoutEndpoint): number {
+  const { env, ms } = MODEL_SERVICE_TIMEOUT_DEFAULTS[endpoint]
+  const raw = readString(env)
+  if (raw === undefined) return ms
+  const parsed = Number.parseInt(raw, 10)
+  if (Number.isFinite(parsed) && parsed > 0) return parsed
+  return ms
+}
+
+const config = Object.freeze({
+  server: Object.freeze({
+    get port(): number {
+      return readInt('PORT', 3001)
+    },
+    get nodeEnv(): string {
+      return readStringWithDefault('NODE_ENV', 'development')
+    },
+    get isProduction(): boolean {
+      return process.env.NODE_ENV === 'production'
+    },
+    get isTest(): boolean {
+      return process.env.NODE_ENV === 'test'
+    },
+    get isDevelopment(): boolean {
+      return readStringWithDefault('NODE_ENV', 'development') === 'development'
+    },
+    get logLevel(): string {
+      return readStringWithDefault('LOG_LEVEL', 'info')
+    },
+  }),
+
+  redis: Object.freeze({
+    get host(): string {
+      return readStringWithDefault('REDIS_HOST', 'localhost')
+    },
+    get port(): number {
+      return readInt('REDIS_PORT', 6379)
+    },
+  }),
+
+  auth: Object.freeze({
+    /** Cookie-signing secret. Insecure dev default; production requires an
+     * override (enforced by `assertStartupConfig`). */
+    get sessionSecret(): string {
+      return readStringWithDefault('SESSION_SECRET', DEV_SESSION_SECRET)
+    },
+    get sessionTimeoutDays(): number {
+      return readInt('SESSION_TIMEOUT_DAYS', 7)
+    },
+    get sessionIdleTimeoutMinutes(): number {
+      return readInt('SESSION_IDLE_TIMEOUT_MINUTES', 60)
+    },
+    get allowRegistration(): boolean {
+      return readBooleanStrictTrue('ALLOW_REGISTRATION')
+    },
+    get allowTestAdminBypass(): boolean {
+      return readBooleanStrictTrue('ALLOW_TEST_ADMIN_BYPASS')
+    },
+    /** Validated 32-byte AES key. Throws when unset or wrong length. */
+    encryptionKey(): Buffer {
+      return resolveEncryptionKey()
+    },
+  }),
+
+  storage: Object.freeze({
+    get path(): string {
+      return readStringWithDefault('STORAGE_PATH', DEFAULT_STORAGE_PATH)
+    },
+    get videoStorageType(): string {
+      return readStringWithDefault('VIDEO_STORAGE_TYPE', 'local')
+    },
+    get videoBaseUrl(): string {
+      return readStringWithDefault('VIDEO_BASE_URL', '/api/videos')
+    },
+    s3: Object.freeze({
+      get bucket(): string | undefined {
+        return readString('S3_BUCKET')
+      },
+      get region(): string | undefined {
+        return readString('S3_REGION')
+      },
+      /** AWS-prefixed key preferred, S3-prefixed key as fallback. */
+      get accessKeyId(): string | undefined {
+        return readString('AWS_ACCESS_KEY_ID') ?? readString('S3_ACCESS_KEY_ID')
+      },
+      get secretAccessKey(): string | undefined {
+        return (
+          readString('AWS_SECRET_ACCESS_KEY') ?? readString('S3_SECRET_ACCESS_KEY')
+        )
+      },
+      get endpoint(): string | undefined {
+        return readString('S3_ENDPOINT')
+      },
+      get publicBucket(): boolean {
+        return readBooleanStrictTrue('S3_PUBLIC_BUCKET')
+      },
+    }),
+    cdn: Object.freeze({
+      get enabled(): boolean {
+        return readBooleanStrictTrue('CDN_ENABLED')
+      },
+      get baseUrl(): string {
+        return readStringWithDefault('CDN_BASE_URL', '')
+      },
+      get signedUrls(): boolean {
+        return readBooleanDefaultTrue('CDN_SIGNED_URLS')
+      },
+    }),
+    thumbnails: Object.freeze({
+      get storageType(): string {
+        return readStringWithDefault('THUMBNAIL_STORAGE_TYPE', 'local')
+      },
+      get path(): string {
+        return readStringWithDefault('THUMBNAIL_PATH', '/videos/thumbnails')
+      },
+      get s3Prefix(): string {
+        return readStringWithDefault('THUMBNAIL_S3_PREFIX', 'thumbnails/')
+      },
+    }),
+  }),
+
+  modelService: Object.freeze({
+    get url(): string {
+      return readStringWithDefault('MODEL_SERVICE_URL', DEFAULT_MODEL_SERVICE_URL)
+    },
+    get adminToken(): string | undefined {
+      return readString('MODEL_SERVICE_ADMIN_TOKEN')
+    },
+    /**
+     * Per-endpoint client-side timeout in milliseconds.
+     *
+     * @param endpoint - which model-service call this timeout applies to
+     * @returns the configured timeout, or the endpoint default when the
+     *   matching `MODEL_SERVICE_TIMEOUT_<NAME>_MS` env var is unset or
+     *   non-positive
+     *
+     * @example
+     * ```typescript
+     * await fetchModelService(url, { timeoutMs: config.modelService.timeoutMs('detection') })
+     * ```
+     */
+    timeoutMs(endpoint: ModelServiceTimeoutEndpoint): number {
+      return resolveTimeoutMs(endpoint)
+    },
+  }),
+
+  rateLimit: Object.freeze({
+    get max(): number {
+      return readInt('RATE_LIMIT_MAX', 1000)
+    },
+    get window(): string {
+      return readStringWithDefault('RATE_LIMIT_WINDOW', '1 minute')
+    },
+  }),
+
+  cors: Object.freeze({
+    /** Comma-split allow-list, or the four localhost defaults when unset. */
+    get allowedOrigins(): string[] {
+      const raw = readString('ALLOWED_ORIGINS')
+      if (raw === undefined) return [...DEFAULT_ALLOWED_ORIGINS]
+      return raw.split(',')
+    },
+  }),
+
+  otel: Object.freeze({
+    get exporterEndpoint(): string {
+      return readStringWithDefault('OTEL_EXPORTER_OTLP_ENDPOINT', DEFAULT_OTEL_ENDPOINT)
+    },
+  }),
+
+  mode: Object.freeze({
+    /** Current FOVEA_MODE (`multi-user` default). */
+    get current(): string {
+      return readStringWithDefault('FOVEA_MODE', DEFAULT_MODE)
+    },
+    get isSingleUser(): boolean {
+      return readStringWithDefault('FOVEA_MODE', DEFAULT_MODE) === 'single-user'
+    },
+  }),
+
+  demo: Object.freeze({
+    /** FOVEA_DEMO_MODE master flag (`'true'` or `'1'`). */
+    get enabled(): boolean {
+      return readBooleanTrueOrOne('FOVEA_DEMO_MODE')
+    },
+    get allowAnonymousAuth(): boolean {
+      return readBooleanTrueOrOne('FOVEA_DEMO_ALLOW_ANONYMOUS_AUTH')
+    },
+    /** Shared seeder secret; null when unset or shorter than 32 chars. */
+    get seedToken(): string | null {
+      const t = process.env.FOVEA_DEMO_SEED_TOKEN
+      if (!t || t.length < 32) return null
+      return t
+    },
+    get clipsManifestPath(): string | undefined {
+      return readString('FOVEA_DEMO_CLIPS_MANIFEST')
+    },
+    get fixturesDir(): string | undefined {
+      return readString('FOVEA_DEMO_FIXTURES_DIR')
+    },
+  }),
+
+  tours: Object.freeze({
+    get dir(): string | undefined {
+      return readString('FOVEA_TOURS_DIR')
+    },
+  }),
+
+  wikidata: Object.freeze({
+    get mode(): string {
+      return readStringWithDefault('WIKIDATA_MODE', 'online')
+    },
+    get url(): string {
+      return readStringWithDefault('WIKIDATA_URL', 'https://www.wikidata.org/w/api.php')
+    },
+    get idMappingPath(): string | undefined {
+      return readString('WIKIBASE_ID_MAPPING_PATH')
+    },
+  }),
+
+  externalLinks: Object.freeze({
+    /** Master ALLOW_EXTERNAL_LINKS switch (on unless explicitly `'false'`). */
+    get master(): boolean {
+      return readBooleanDefaultTrue('ALLOW_EXTERNAL_LINKS')
+    },
+    /**
+     * Whether Wikidata links are allowed.
+     *
+     * Online mode always allows them. Offline mode is governed by
+     * `ALLOW_EXTERNAL_WIKIDATA_LINKS`, falling back to the master switch
+     * when that specific var is unset.
+     *
+     * @param wikidataMode - the resolved Wikidata mode (`online`/`offline`)
+     * @returns true when Wikidata links should be shown
+     */
+    wikidata(wikidataMode: string): boolean {
+      return (
+        wikidataMode === 'online' ||
+        readBooleanStrictTrue('ALLOW_EXTERNAL_WIKIDATA_LINKS') ||
+        (readBooleanDefaultTrue('ALLOW_EXTERNAL_WIKIDATA_LINKS') &&
+          readBooleanDefaultTrue('ALLOW_EXTERNAL_LINKS'))
+      )
+    },
+    /**
+     * Whether external video-source links (uploader/webpage URLs) are
+     * allowed. Governed by `ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS`, falling
+     * back to the master switch when that specific var is unset.
+     *
+     * @returns true when video-source links should be shown
+     */
+    get videoSources(): boolean {
+      return (
+        readBooleanStrictTrue('ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS') ||
+        (readBooleanDefaultTrue('ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS') &&
+          readBooleanDefaultTrue('ALLOW_EXTERNAL_LINKS'))
+      )
+    },
+  }),
+
+  defaultUser: Object.freeze({
+    get username(): string {
+      return readStringWithDefault('DEFAULT_USER_USERNAME', 'default-user')
+    },
+    get displayName(): string {
+      return readStringWithDefault('DEFAULT_USER_DISPLAY_NAME', 'Default User')
+    },
+  }),
+
+  /**
+   * Resolve a provider's API key from the conventional env var.
+   *
+   * Reads `<PROVIDER>_API_KEY` (provider upper-cased), e.g. `anthropic`
+   * reads `ANTHROPIC_API_KEY`. Used as a fallback when no admin-stored
+   * key exists for the provider.
+   *
+   * @param provider - provider name (case-insensitive), e.g. `anthropic`
+   * @returns the key string, or undefined when the env var is unset/empty
+   *
+   * @example
+   * ```typescript
+   * const key = config.getProviderApiKey('anthropic')
+   * ```
+   */
+  getProviderApiKey(provider: string): string | undefined {
+    return readString(`${provider.toUpperCase()}_API_KEY`)
+  },
+})
+
+assertStartupConfig()
+
+export { config }

--- a/server/src/demo/anonymous-session.ts
+++ b/server/src/demo/anonymous-session.ts
@@ -25,6 +25,7 @@ import crypto from 'node:crypto'
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify'
 import { prisma } from '../lib/prisma.js'
 import { authService } from '../services/auth-service.js'
+import { config } from '../config.js'
 import { isAnonymousAuthAllowed } from './config.js'
 
 interface AnonymousSessionResponse {
@@ -109,7 +110,7 @@ const anonymousSessionPlugin: FastifyPluginAsync = async (app: FastifyInstance) 
 
       reply.setCookie('session_token', token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: config.server.isProduction,
         sameSite: 'lax',
         expires: expiresAt,
         path: '/',

--- a/server/src/demo/config.ts
+++ b/server/src/demo/config.ts
@@ -23,6 +23,7 @@
 // their existing import path. The implementation lives in lib/ so
 // product code can also import it without violating the demo->product
 // layering rule enforced by eslint no-restricted-imports.
+import { config } from '../config.js'
 import { isDemoModeEnabled } from '../lib/demo-flags.js'
 export { isDemoModeEnabled }
 
@@ -35,11 +36,7 @@ export { isDemoModeEnabled }
  * unauthenticated access on a production deployment.
  */
 export function isAnonymousAuthAllowed(): boolean {
-  return (
-    isDemoModeEnabled() &&
-    (process.env.FOVEA_DEMO_ALLOW_ANONYMOUS_AUTH === 'true' ||
-      process.env.FOVEA_DEMO_ALLOW_ANONYMOUS_AUTH === '1')
-  )
+  return isDemoModeEnabled() && config.demo.allowAnonymousAuth
 }
 
 /**
@@ -48,7 +45,5 @@ export function isAnonymousAuthAllowed(): boolean {
  * is checked via `X-Demo-Seed-Token` header — a 32+ char random secret.
  */
 export function getSeedToken(): string | null {
-  const t = process.env.FOVEA_DEMO_SEED_TOKEN
-  if (!t || t.length < 32) return null
-  return t
+  return config.demo.seedToken
 }

--- a/server/src/demo/seed.ts
+++ b/server/src/demo/seed.ts
@@ -24,6 +24,7 @@ import { readFile } from 'node:fs/promises'
 import { resolve, join } from 'node:path'
 import { timingSafeEqual } from 'node:crypto'
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify'
+import { config } from '../config.js'
 import { prisma } from '../lib/prisma.js'
 import { getSeedToken, isDemoModeEnabled } from './config.js'
 import {
@@ -59,7 +60,7 @@ interface ClipManifest {
  * from the server cwd to the monorepo location.
  */
 function manifestPath(): string {
-  const overridden = process.env.FOVEA_DEMO_CLIPS_MANIFEST
+  const overridden = config.demo.clipsManifestPath
   if (overridden && overridden.length > 0) return overridden
   return resolve(
     process.cwd(),
@@ -102,7 +103,7 @@ interface SeedSuccess {
  * pattern for custom tours).
  */
 function fixturesDir(): string {
-  const overridden = process.env.FOVEA_DEMO_FIXTURES_DIR
+  const overridden = config.demo.fixturesDir
   if (overridden && overridden.length > 0) return overridden
   return resolve(process.cwd(), '..', 'annotation-tool', 'demo', 'fixtures')
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,22 +1,21 @@
-// Initialize OpenTelemetry tracing FIRST, before any other imports
-// This allows auto-instrumentation to hook into libraries as they load
+// Load and validate configuration FIRST, before any other import.
+// `config` reads process.env once, fails fast on invalid/missing required
+// values, and must throw before OTEL, Fastify, or Prisma initialize.
+import { config } from './config.js'
+// Initialize OpenTelemetry tracing before the remaining imports so
+// auto-instrumentation can hook into libraries as they load.
 import './tracing.js'
 
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
 import fs from 'fs/promises'
 import { buildApp } from './app.js'
 import { ensureDefaultUser, isSingleUserMode } from './services/user-service.js'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
 
 /**
  * Initializes the data directory for video storage.
  * Checks if the data directory exists and logs the result.
  */
 async function initializeDataDirectory() {
-  const dataDir = process.env.STORAGE_PATH || join(dirname(__dirname), '..', 'videos')
+  const dataDir = config.storage.path
   try {
     await fs.access(dataDir)
     console.log(`Data directory found at: ${dataDir}`)
@@ -45,10 +44,8 @@ async function initializeSingleUserMode() {
  * Production deployments should use manual sync via API.
  */
 async function initializeVideoSync(app: Awaited<ReturnType<typeof buildApp>>) {
-  const nodeEnv = process.env.NODE_ENV || 'development'
-
   // Only auto-sync in dev/test - production should sync manually
-  if (nodeEnv !== 'production') {
+  if (!config.server.isProduction) {
     try {
       // Import storage modules
       const { loadStorageConfig, createVideoStorageProvider } = await import('./services/videoStorage.js')
@@ -140,7 +137,7 @@ async function initializeSystemConfigReplay(app: Awaited<ReturnType<typeof build
 
 async function start() {
   const app = await buildApp()
-  const PORT = parseInt(process.env.PORT || '3001', 10)
+  const PORT = config.server.port
 
   try {
     await connectDatabase()

--- a/server/src/lib/custom-tours.ts
+++ b/server/src/lib/custom-tours.ts
@@ -21,6 +21,8 @@
 import { readdir, readFile, stat } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 
+import { config } from '../config.js'
+
 export interface CustomTourSummary {
   id: string
   title: string
@@ -43,7 +45,7 @@ const VALID_EXTS = new Set(['.json', '.yaml', '.yml'])
  * never authored a custom tour pays nothing.
  */
 export async function loadCustomTours(): Promise<LoaderResult> {
-  const dir = process.env.FOVEA_TOURS_DIR
+  const dir = config.tours.dir
   if (!dir || dir.length === 0) {
     return { tours: [], failures: [] }
   }

--- a/server/src/lib/demo-flags.ts
+++ b/server/src/lib/demo-flags.ts
@@ -13,13 +13,14 @@
  * re-exports through `demo/config.js` so its own callers do not
  * cross the boundary in either direction.
  *
- * Keep this file dependency-free. It is read by both layers and a
- * misplaced cross-import here would defeat the layering rule.
+ * Keep this file free of cross-layer imports. It reads the flag through
+ * the central config module (the single env reader) and is consumed by
+ * both layers; a misplaced cross-import here would defeat the layering
+ * rule.
  */
 
+import { config } from '../config.js'
+
 export function isDemoModeEnabled(): boolean {
-  return (
-    process.env.FOVEA_DEMO_MODE === 'true' ||
-    process.env.FOVEA_DEMO_MODE === '1'
-  )
+  return config.demo.enabled
 }

--- a/server/src/lib/encryption.ts
+++ b/server/src/lib/encryption.ts
@@ -5,29 +5,20 @@
 
 import crypto from 'node:crypto';
 
+import { config } from '../config.js';
+
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
-const KEY_LENGTH = 32;
 
 /**
- * Gets the encryption key from environment variable.
+ * Gets the validated encryption key from configuration.
  *
  * @returns Encryption key as Buffer
- * @throws Error if API_KEY_ENCRYPTION_KEY not configured or invalid length
+ * @throws {Error} if API_KEY_ENCRYPTION_KEY is unset or not 32 bytes
  */
 function getEncryptionKey(): Buffer {
-  const key = process.env.API_KEY_ENCRYPTION_KEY;
-  if (!key) {
-    throw new Error('API_KEY_ENCRYPTION_KEY environment variable not set');
-  }
-
-  const keyBuffer = Buffer.from(key, 'hex');
-  if (keyBuffer.length !== KEY_LENGTH) {
-    throw new Error(`API_KEY_ENCRYPTION_KEY must be ${KEY_LENGTH} bytes (${KEY_LENGTH * 2} hex characters)`);
-  }
-
-  return keyBuffer;
+  return config.auth.encryptionKey();
 }
 
 /**

--- a/server/src/lib/fetchModelService.ts
+++ b/server/src/lib/fetchModelService.ts
@@ -16,6 +16,8 @@
  * fetch-based call sites.
  */
 
+import { config } from '../config.js'
+
 export class ModelServiceTimeoutError extends Error {
   readonly endpoint: string
   readonly timeoutMs: number
@@ -85,43 +87,42 @@ export async function fetchModelService(
   }
 }
 
-/** Parse a positive-integer env var, falling back to a default when unset
- * or malformed. Used by the per-endpoint timeouts below so deployments
- * with slower upstream hardware (CPU-only model-service, cold-start
- * cloud instances) can raise the ceiling without a code change.
- */
-function envTimeoutMs(name: string, defaultMs: number): number {
-  const raw = process.env[name]
-  if (raw === undefined || raw === '') return defaultMs
-  const parsed = Number.parseInt(raw, 10)
-  if (Number.isFinite(parsed) && parsed > 0) return parsed
-  return defaultMs
-}
-
-/** Per-endpoint timeout defaults. Each value is the upper bound the
+/** Per-endpoint timeout accessors. Each value is the upper bound the
  * backend waits before aborting a forwarded request to the model-
  * service and surfacing 504 MODEL_SERVICE_TIMEOUT to the caller. The
- * defaults below target a GPU-warm production deployment; CPU-cold
- * first-load (e.g. the integration-models E2E stack) is materially
- * slower (an LLM augmenter call took 94s on first invocation, beyond
- * the prior 60s detection / augment ceilings), so deployments that
- * need higher ceilings override these via the matching env vars.
- */
-export const MODEL_SERVICE_TIMEOUTS = {
+ * defaults target a GPU-warm production deployment; CPU-cold first-load
+ * (e.g. the integration-models E2E stack) is materially slower, so
+ * deployments that need higher ceilings override via the matching
+ * `MODEL_SERVICE_TIMEOUT_<NAME>_MS` env var. Values are resolved through
+ * `config.modelService.timeoutMs` so the env surface lives in one place;
+ * each property reads at access time so an env override is honored. */
+export const MODEL_SERVICE_TIMEOUTS = Object.freeze({
   /** Detection across N frames: heavier than a simple inference. */
-  detection: envTimeoutMs('MODEL_SERVICE_TIMEOUT_DETECTION_MS', 60_000),
+  get detection(): number {
+    return config.modelService.timeoutMs('detection')
+  },
   /** Single-frame thumbnail render. */
-  thumbnails: envTimeoutMs('MODEL_SERVICE_TIMEOUT_THUMBNAILS_MS', 30_000),
+  get thumbnails(): number {
+    return config.modelService.timeoutMs('thumbnails')
+  },
   /** LLM-backed ontology suggestion. */
-  ontologyAugment: envTimeoutMs('MODEL_SERVICE_TIMEOUT_ONTOLOGY_AUGMENT_MS', 60_000),
+  get ontologyAugment(): number {
+    return config.modelService.timeoutMs('ontologyAugment')
+  },
   /** Transcription / summarization over a whole video. */
-  summarize: envTimeoutMs('MODEL_SERVICE_TIMEOUT_SUMMARIZE_MS', 300_000),
+  get summarize(): number {
+    return config.modelService.timeoutMs('summarize')
+  },
   /** Claim extraction over a summary. */
-  extractClaims: envTimeoutMs('MODEL_SERVICE_TIMEOUT_EXTRACT_CLAIMS_MS', 300_000),
+  get extractClaims(): number {
+    return config.modelService.timeoutMs('extractClaims')
+  },
   /** Synthesizing a final summary from extracted claims. */
-  synthesize: envTimeoutMs('MODEL_SERVICE_TIMEOUT_SYNTHESIZE_MS', 300_000),
-  /** Audio transcription over a video / audio file. faster-whisper-tiny
-   * on CPU does a 14 s clip in ~6 s cold, ~3 s warm, but a longer
-   * input or larger model can run minutes; default 5 min. */
-  transcribe: envTimeoutMs('MODEL_SERVICE_TIMEOUT_TRANSCRIBE_MS', 300_000),
-} as const
+  get synthesize(): number {
+    return config.modelService.timeoutMs('synthesize')
+  },
+  /** Audio transcription over a video / audio file. */
+  get transcribe(): number {
+    return config.modelService.timeoutMs('transcribe')
+  },
+})

--- a/server/src/lib/prisma.ts
+++ b/server/src/lib/prisma.ts
@@ -1,11 +1,13 @@
 import { PrismaClient } from '@prisma/client'
 
+import { config } from '../config.js'
+
 /**
  * Prisma Client singleton instance.
  * Ensures only one instance is created and reused across the application.
  */
 export const prisma = new PrismaClient({
-  log: process.env.NODE_ENV === 'development'
+  log: config.server.isDevelopment
     ? ['query', 'error', 'warn']
     : ['error']
 })

--- a/server/src/lib/session.ts
+++ b/server/src/lib/session.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto'
+import { config } from '../config.js'
 import { prisma } from './prisma.js'
-
-const SESSION_TIMEOUT_DAYS = parseInt(process.env.SESSION_TIMEOUT_DAYS || '7', 10)
 
 /**
  * Generates a secure random session token.
@@ -26,7 +25,7 @@ export async function createSession(
   userAgent?: string
 ) {
   const token = generateSessionToken()
-  const daysToExpire = rememberMe ? 30 : SESSION_TIMEOUT_DAYS
+  const daysToExpire = rememberMe ? 30 : config.auth.sessionTimeoutDays
   const expiresAt = new Date()
   expiresAt.setDate(expiresAt.getDate() + daysToExpire)
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { FastifyRequest, FastifyReply } from 'fastify'
+import { config } from '../config.js'
 import { authService } from '../services/auth-service.js'
 import { UnauthorizedError, ForbiddenError } from '../lib/errors.js'
 
@@ -73,7 +74,7 @@ export async function requireAdmin(
 ): Promise<void> {
   // Test mode bypass for E2E tests
   // Allows admin API access without authentication in isolated test environment
-  if (process.env.NODE_ENV === 'test' && process.env.ALLOW_TEST_ADMIN_BYPASS === 'true') {
+  if (config.server.isTest && config.auth.allowTestAdminBypass) {
     // Auto-authenticate as test admin user
     request.user = {
       id: 'test-admin',

--- a/server/src/queues/setup.ts
+++ b/server/src/queues/setup.ts
@@ -8,6 +8,7 @@ import {
   modelServiceCounter,
   modelServiceDuration,
 } from "../metrics.js";
+import { config as appConfig } from "../config.js";
 import { buildPersonaPrompts } from "../utils/queryBuilder.js";
 import {
   fetchModelService,
@@ -73,8 +74,8 @@ interface ModelSummarizeRequest {
  * Uses environment variables with localhost defaults for development.
  */
 const connection = new Redis({
-  host: process.env.REDIS_HOST || "localhost",
-  port: parseInt(process.env.REDIS_PORT || "6379"),
+  host: appConfig.redis.host,
+  port: appConfig.redis.port,
   maxRetriesPerRequest: null,
 });
 
@@ -251,8 +252,7 @@ export const videoWorker = new Worker<
     const modelVideoPath = video.path.replace('/data/', '/videos/');
 
     // Call model service with metrics tracking
-    const modelServiceUrl =
-      process.env.MODEL_SERVICE_URL || "http://localhost:8000";
+    const modelServiceUrl = appConfig.modelService.url;
     const modelStartTime = Date.now();
 
     const camelCaseRequest = {
@@ -582,8 +582,7 @@ export const claimWorker = new Worker<
     }
 
     // Call model service
-    const modelServiceUrl =
-      process.env.MODEL_SERVICE_URL || "http://localhost:8000";
+    const modelServiceUrl = appConfig.modelService.url;
     const modelStartTime = Date.now();
 
     await job.updateProgress(30);
@@ -936,8 +935,7 @@ export const synthesisWorker = new Worker<
     const requestBody = snakecaseKeys(camelCaseRequestBody, { deep: true });
 
     // Call model service
-    const modelServiceUrl =
-      process.env.MODEL_SERVICE_URL || "http://localhost:8000";
+    const modelServiceUrl = appConfig.modelService.url;
     const modelStartTime = Date.now();
 
     await job.updateProgress(30);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -15,8 +15,10 @@ import {
   recordSessionEvent,
 } from '../lib/authMetrics.js'
 import { requireAuth } from '../middleware/auth.js'
+import { config } from '../config.js'
 import { buildAbilities } from '../middleware/abilities.js'
 import { serializeAbilities } from '../lib/abilities.js'
+import { isSingleUserMode } from '../services/user-service.js'
 
 /**
  * Authentication routes for login, logout, registration.
@@ -133,7 +135,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       // Set session cookie
       reply.setCookie('session_token', token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: config.server.isProduction,
         sameSite: 'lax',
         expires: expiresAt,
         path: '/',
@@ -213,7 +215,6 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const token = request.cookies.session_token
-      const mode = process.env.FOVEA_MODE || 'single-user'
 
       // Handle session-based authentication
       if (token) {
@@ -236,7 +237,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       // In single-user mode, auto-authenticate with default user
-      if (mode === 'single-user') {
+      if (isSingleUserMode()) {
         // Find default user by id (matches what seed.ts creates)
         const defaultUserId = 'default-user'
         let defaultUser = await prisma.user.findUnique({
@@ -270,7 +271,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         // Set session cookie
         reply.setCookie('session_token', sessionToken, {
           httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
+          secure: config.server.isProduction,
           sameSite: 'lax',
           expires: expiresAt,
           path: '/',
@@ -338,7 +339,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       // Check if registration is enabled
-      if (process.env.ALLOW_REGISTRATION !== 'true') {
+      if (!config.auth.allowRegistration) {
         throw new ForbiddenError('Registration is disabled')
       }
 
@@ -378,7 +379,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
 
       reply.setCookie('session_token', token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: config.server.isProduction,
         sameSite: 'lax',
         expires: expiresAt,
         path: '/',
@@ -486,7 +487,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       // Update cookie with new expiration
       reply.setCookie('session_token', token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: config.server.isProduction,
         sameSite: 'lax',
         expires: newExpiresAt,
         path: '/',

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { existsSync, readFileSync } from 'fs'
+import { config } from '../config.js'
 
 /**
  * Load ID mapping from file if it exists.
@@ -29,33 +30,22 @@ export default async function configRoutes(fastify: FastifyInstance) {
    * @returns Configuration object with mode, allowRegistration, and wikidata settings
    */
   fastify.get('/api/config', async () => {
-    const mode = process.env.FOVEA_MODE || 'single-user'
-    const allowRegistration = process.env.ALLOW_REGISTRATION === 'true'
+    const mode = config.mode.current
+    const allowRegistration = config.auth.allowRegistration
 
     // Wikidata/Wikibase configuration
-    const wikidataMode = process.env.WIKIDATA_MODE || 'online'
-    const wikidataUrl =
-      process.env.WIKIDATA_URL || 'https://www.wikidata.org/w/api.php'
+    const wikidataMode = config.wikidata.mode
+    const wikidataUrl = config.wikidata.url
 
     // Load ID mapping for offline mode
-    const idMappingPath = process.env.WIKIBASE_ID_MAPPING_PATH
+    const idMappingPath = config.wikidata.idMappingPath
     const idMapping =
       wikidataMode === 'offline' ? loadIdMapping(idMappingPath) : null
 
-    // External link controls
-    // ALLOW_EXTERNAL_LINKS is a master switch that defaults both specific settings
-    const masterExternalLinks = process.env.ALLOW_EXTERNAL_LINKS !== 'false'
-
-    // Wikidata links: In online mode, always allowed. In offline mode, controlled by env var.
-    const allowExternalWikidataLinks =
-      wikidataMode === 'online' ||
-      (process.env.ALLOW_EXTERNAL_WIKIDATA_LINKS === 'true' ||
-        (process.env.ALLOW_EXTERNAL_WIKIDATA_LINKS !== 'false' && masterExternalLinks))
-
-    // Video source links (uploaderUrl, webpageUrl): controlled by env var
-    const allowExternalVideoSourceLinks =
-      process.env.ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS === 'true' ||
-      (process.env.ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS !== 'false' && masterExternalLinks)
+    // External link controls. ALLOW_EXTERNAL_LINKS is a master switch
+    // that defaults both specific settings; the derivation lives in config.
+    const allowExternalWikidataLinks = config.externalLinks.wikidata(wikidataMode)
+    const allowExternalVideoSourceLinks = config.externalLinks.videoSources
 
     return {
       mode: mode as 'single-user' | 'multi-user',

--- a/server/src/routes/models.ts
+++ b/server/src/routes/models.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify'
 import axios, { AxiosError } from 'axios'
 import camelcaseKeys from 'camelcase-keys'
+import { config } from '../config.js'
 import { InternalError, ValidationError } from '../lib/errors.js'
 
 /**
@@ -56,7 +57,7 @@ function normalizeAndAssertTaskType(taskType: string): string {
  */
 
 const modelsRoute: FastifyPluginAsync = async (fastify) => {
-  const MODEL_SERVICE_URL = process.env.MODEL_SERVICE_URL || 'http://model-service:8000'
+  const MODEL_SERVICE_URL = config.modelService.url
 
   /**
    * Get model configuration.

--- a/server/src/routes/ontology.ts
+++ b/server/src/routes/ontology.ts
@@ -3,8 +3,10 @@ import { FastifyPluginAsync } from 'fastify'
 import { Prisma } from '@prisma/client'
 import { subject } from '@casl/ability'
 import { requireAuth } from '../middleware/auth.js'
+import { config } from '../config.js'
 import { buildAbilities } from '../middleware/abilities.js'
 import { NotFoundError, UnauthorizedError, InternalError, ForbiddenError, AppError } from '../lib/errors.js'
+import { isSingleUserMode } from '../services/user-service.js'
 import {
   fetchModelService,
   MODEL_SERVICE_TIMEOUTS,
@@ -83,16 +85,14 @@ const ontologyRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    const mode = process.env.FOVEA_MODE || 'multi-user'
-
     // Get user ID: use authenticated user or find default user in single-user mode
     let userId: string
     if (request.user) {
       userId = request.user.id
-    } else if (mode === 'single-user') {
+    } else if (isSingleUserMode()) {
       // Find default user
       const defaultUser = await fastify.prisma.user.findFirst({
-        where: { username: process.env.DEFAULT_USER_USERNAME || 'default-user' }
+        where: { username: config.defaultUser.username }
       })
       if (!defaultUser) {
         throw new InternalError('Default user not found in single-user mode')
@@ -197,16 +197,14 @@ const ontologyRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    const mode = process.env.FOVEA_MODE || 'multi-user'
-
     // Get user ID: use authenticated user or find default user in single-user mode
     let userId: string
     if (request.user) {
       userId = request.user.id
-    } else if (mode === 'single-user') {
+    } else if (isSingleUserMode()) {
       // Find default user
       const defaultUser = await fastify.prisma.user.findFirst({
-        where: { username: process.env.DEFAULT_USER_USERNAME || 'default-user' }
+        where: { username: config.defaultUser.username }
       })
       if (!defaultUser) {
         throw new InternalError('Default user not found in single-user mode')
@@ -467,7 +465,7 @@ const ontologyRoute: FastifyPluginAsync = async (fastify) => {
       }
 
       // Call model service
-      const modelServiceUrl = process.env.MODEL_SERVICE_URL || 'http://localhost:8000'
+      const modelServiceUrl = config.modelService.url
       const response = await fetchModelService(`${modelServiceUrl}/api/ontology/augment`, {
         method: 'POST',
         timeoutMs: MODEL_SERVICE_TIMEOUTS.ontologyAugment,

--- a/server/src/routes/personas.ts
+++ b/server/src/routes/personas.ts
@@ -8,6 +8,7 @@ import { requireAuth, optionalAuth } from '@middleware/auth.js'
 import { buildAbilities } from '../middleware/abilities.js'
 import { NotFoundError, ForbiddenError } from '@lib/errors.js'
 import { isDemoModeEnabled } from '../lib/demo-flags.js'
+import { isSingleUserMode } from '@services/user-service.js'
 import { personaOperationCounter } from '../metrics.js'
 import {
   updateGlossesInTypes,
@@ -117,9 +118,7 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    const mode = process.env.FOVEA_MODE || 'multi-user'
-
-    if (mode === 'single-user') {
+    if (isSingleUserMode()) {
       // Single-user mode: return all non-hidden personas
       const personas = await fastify.prisma.persona.findMany({
         where: { hidden: false },
@@ -156,7 +155,7 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
     // single-user deployment shows. This is gated on FOVEA_DEMO_MODE
     // so production multi-user deployments keep their per-user RBAC
     // intact.
-    if (process.env.FOVEA_DEMO_MODE === 'true') {
+    if (isDemoModeEnabled()) {
       // The seeded Automated persona ships with hidden=true so it
       // does not clutter a multi-user deployment's persona dropdown
       // for end users who do not need it. The tour flow that walks

--- a/server/src/routes/telemetry.ts
+++ b/server/src/routes/telemetry.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify'
 import { Type, Static } from '@sinclair/typebox'
+import { config } from '../config.js'
 import { recordFrontendError, type ErrorSeverity } from '../lib/errorMetrics.js'
 
 /**
@@ -188,7 +189,7 @@ const telemetryRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request, reply) => {
-      const otelEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://otel-collector:4318'
+      const otelEndpoint = config.otel.exporterEndpoint
       const tracesUrl = `${otelEndpoint}/v1/traces`
 
       try {

--- a/server/src/routes/videos/detect.ts
+++ b/server/src/routes/videos/detect.ts
@@ -3,6 +3,7 @@ import { Type, Static } from '@sinclair/typebox'
 import { PrismaClient } from '@prisma/client'
 import camelcaseKeys from 'camelcase-keys'
 import snakecaseKeys from 'snakecase-keys'
+import { config } from '../../config.js'
 import { buildDetectionQueryFromPersona, DetectionQueryOptions } from '../../utils/queryBuilder.js'
 import { VideoRepository } from '../../repositories/VideoRepository.js'
 import { DetectionRequestSchema, DetectionResponseSchema } from './schemas.js'
@@ -128,7 +129,7 @@ export const detectRoutes: FastifyPluginAsync<{
         // Backend uses /data, model service uses /videos
         const modelVideoPath = video.path.replace('/data/', '/videos/')
 
-        const modelServiceUrl = process.env.MODEL_SERVICE_URL || 'http://localhost:8000'
+        const modelServiceUrl = config.modelService.url
 
         const requestBody = snakecaseKeys({
           videoId,

--- a/server/src/routes/videos/index.ts
+++ b/server/src/routes/videos/index.ts
@@ -1,4 +1,5 @@
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify'
+import { config } from '../../config.js'
 import { createVideoStorageProvider, loadStorageConfig } from '../../services/videoStorage.js'
 import { VideoRepository } from '../../repositories/VideoRepository.js'
 import { VideoAccessService } from '../../services/video-access-service.js'
@@ -26,7 +27,7 @@ import { urlRoutes } from './url.js'
  * - Get video URLs
  */
 const videosRoute: FastifyPluginAsync = async (fastify) => {
-  const STORAGE_PATH = process.env.STORAGE_PATH || '/videos'
+  const STORAGE_PATH = config.storage.path
 
   // Initialize storage provider
   const storageConfig = loadStorageConfig()

--- a/server/src/routes/videos/thumbnail.ts
+++ b/server/src/routes/videos/thumbnail.ts
@@ -3,6 +3,7 @@ import { Type } from '@sinclair/typebox'
 import { promises as fs } from 'fs'
 import path from 'path'
 import { createReadStream } from 'fs'
+import { config } from '../../config.js'
 import { VideoRepository } from '../../repositories/VideoRepository.js'
 import { VideoStorageProvider, VideoStorageConfig } from '../../services/videoStorage.js'
 import { NotFoundError, InternalError, AppError } from '../../lib/errors.js'
@@ -85,7 +86,7 @@ export const thumbnailRoutes: FastifyPluginAsync<{
       }
 
       // Generate thumbnail via model service
-      const modelServiceUrl = process.env.MODEL_SERVICE_URL || 'http://localhost:8000'
+      const modelServiceUrl = config.modelService.url
 
       // Get video URL that model service can access
       // For local storage, this will be a file path

--- a/server/src/routes/videos/transcribe.ts
+++ b/server/src/routes/videos/transcribe.ts
@@ -2,6 +2,7 @@ import { FastifyPluginAsync } from 'fastify'
 import { Type } from '@sinclair/typebox'
 import { PrismaClient } from '@prisma/client'
 import camelcaseKeys from 'camelcase-keys'
+import { config } from '../../config.js'
 import { VideoRepository } from '../../repositories/VideoRepository.js'
 import { NotFoundError, AppError, ErrorResponseSchema } from '../../lib/errors.js'
 import {
@@ -137,7 +138,7 @@ export const transcribeRoutes: FastifyPluginAsync<{
       }
 
       const modelVideoPath = video.path.replace('/data/', '/videos/')
-      const modelServiceUrl = process.env.MODEL_SERVICE_URL || 'http://localhost:8000'
+      const modelServiceUrl = config.modelService.url
 
       try {
         const transcribeRes = await fetchModelService(`${modelServiceUrl}/api/transcribe`, {

--- a/server/src/routes/world.ts
+++ b/server/src/routes/world.ts
@@ -4,10 +4,12 @@ import { Prisma, type WorldState as PrismaWorldState } from '@prisma/client'
 import { accessibleBy } from '@casl/prisma'
 import { subject } from '@casl/ability'
 import { optionalAuth, requireAdmin, requireAuth } from '@middleware/auth.js'
+import { config } from '../config.js'
 import { buildAbilities } from '../middleware/abilities.js'
 import type { AppAbility } from '../lib/abilities.js'
 import { NotFoundError, UnauthorizedError, InternalError, ForbiddenError } from '@lib/errors.js'
 import { isDemoModeEnabled } from '../lib/demo-flags.js'
+import { isSingleUserMode } from '@services/user-service.js'
 import { convertObjectRefsToText, countObjectRefsInGlosses } from '@lib/reference-cleanup.js'
 import {
   asEntityTypes,
@@ -97,16 +99,14 @@ const worldRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    const mode = process.env.FOVEA_MODE || 'multi-user'
-
     // Get user ID: use authenticated user or find default user in single-user mode
     let userId: string
     if (request.user) {
       userId = request.user.id
-    } else if (mode === 'single-user') {
+    } else if (isSingleUserMode()) {
       // Find default user
       const defaultUser = await fastify.prisma.user.findFirst({
-        where: { username: process.env.DEFAULT_USER_USERNAME || 'default-user' }
+        where: { username: config.defaultUser.username }
       })
       if (!defaultUser) {
         throw new InternalError('Default user not found in single-user mode')
@@ -219,16 +219,14 @@ const worldRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    const mode = process.env.FOVEA_MODE || 'multi-user'
-
     // Get user ID: use authenticated user or find default user in single-user mode
     let userId: string
     if (request.user) {
       userId = request.user.id
-    } else if (mode === 'single-user') {
+    } else if (isSingleUserMode()) {
       // Find default user
       const defaultUser = await fastify.prisma.user.findFirst({
-        where: { username: process.env.DEFAULT_USER_USERNAME || 'default-user' }
+        where: { username: config.defaultUser.username }
       })
       if (!defaultUser) {
         throw new InternalError('Default user not found in single-user mode')
@@ -387,13 +385,11 @@ const worldRoute: FastifyPluginAsync = async (fastify) => {
    * Helper to get user ID from request or default user.
    */
   async function getUserId(request: { user?: { id: string } }): Promise<string> {
-    const mode = process.env.FOVEA_MODE || 'multi-user'
-
     if (request.user) {
       return request.user.id
-    } else if (mode === 'single-user') {
+    } else if (isSingleUserMode()) {
       const defaultUser = await fastify.prisma.user.findFirst({
-        where: { username: process.env.DEFAULT_USER_USERNAME || 'default-user' }
+        where: { username: config.defaultUser.username }
       })
       if (!defaultUser) {
         throw new InternalError('Default user not found in single-user mode')

--- a/server/src/services/api-key-service.ts
+++ b/server/src/services/api-key-service.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, ApiKey } from '@prisma/client'
+import { config } from '../config.js'
 import { encryptApiKey, decryptApiKey } from '../lib/encryption.js'
 
 /**
@@ -250,10 +251,7 @@ export async function resolveApiKey(
   }
 
   // Try environment variable
-  const envVarName = `${provider.toUpperCase()}_API_KEY`
-  const envKey = process.env[envVarName]
-
-  return envKey || null
+  return config.getProviderApiKey(provider) ?? null
 }
 
 /**

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -1,18 +1,9 @@
 import crypto from 'crypto'
+import { config } from '../config.js'
 import { prisma } from '../lib/prisma.js'
 import { User, Session } from '@prisma/client'
 import { AuthProvider, AuthCredentials, AuthResult } from './auth/types.js'
 import { PasswordAuthProvider } from './auth/password-provider.js'
-
-/**
- * Session idle timeout in minutes.
- * Sessions are invalidated if there is no activity for this duration.
- * Configurable via SESSION_IDLE_TIMEOUT_MINUTES environment variable.
- */
-const SESSION_IDLE_TIMEOUT_MINUTES = parseInt(
-  process.env.SESSION_IDLE_TIMEOUT_MINUTES || '60',
-  10
-)
 
 /**
  * Authentication service managing providers and sessions.
@@ -120,7 +111,7 @@ export class AuthService {
     }
 
     // Check idle timeout
-    const idleTimeoutMs = SESSION_IDLE_TIMEOUT_MINUTES * 60 * 1000
+    const idleTimeoutMs = config.auth.sessionIdleTimeoutMinutes * 60 * 1000
     const lastActivity = session.lastActivityAt || session.createdAt
     if (now.getTime() - lastActivity.getTime() > idleTimeoutMs) {
       // Session has been idle too long

--- a/server/src/services/system-config-propagator.ts
+++ b/server/src/services/system-config-propagator.ts
@@ -16,6 +16,8 @@ import axios, { AxiosError } from 'axios'
 import type { FastifyBaseLogger } from 'fastify'
 import type { PrismaClient } from '@prisma/client'
 
+import { config } from '../config.js'
+
 interface AdminPushPayload {
   key: string
   value: unknown
@@ -42,8 +44,8 @@ export async function pushSystemConfigRow(
   log: Pick<FastifyBaseLogger, 'warn' | 'info'>,
   payload: AdminPushPayload
 ): Promise<PushResult> {
-  const modelServiceUrl = process.env.MODEL_SERVICE_URL || 'http://model-service:8000'
-  const token = process.env.MODEL_SERVICE_ADMIN_TOKEN
+  const modelServiceUrl = config.modelService.url
+  const token = config.modelService.adminToken
   if (!token) {
     log.warn('MODEL_SERVICE_ADMIN_TOKEN not set; skipping SystemConfig propagation')
     return 'skipped-no-token'

--- a/server/src/services/user-service.ts
+++ b/server/src/services/user-service.ts
@@ -1,3 +1,4 @@
+import { config } from '../config.js'
 import { prisma } from '../lib/prisma.js'
 import type { User } from '@prisma/client'
 
@@ -14,10 +15,8 @@ import type { User } from '@prisma/client'
  * @returns Default user record
  */
 export async function ensureDefaultUser(): Promise<User> {
-  const mode = process.env.FOVEA_MODE || 'multi-user'
-
   // Only relevant for single-user mode
-  if (mode !== 'single-user') {
+  if (!isSingleUserMode()) {
     throw new Error('ensureDefaultUser should only be called in single-user mode')
   }
 
@@ -34,8 +33,8 @@ export async function ensureDefaultUser(): Promise<User> {
   const defaultUser = await prisma.user.create({
     data: {
       id: 'default-user',
-      username: process.env.DEFAULT_USER_USERNAME || 'default-user',
-      displayName: process.env.DEFAULT_USER_DISPLAY_NAME || 'Default User',
+      username: config.defaultUser.username,
+      displayName: config.defaultUser.displayName,
       email: null,
       passwordHash: null, // No password in single-user mode
       isAdmin: true
@@ -62,6 +61,5 @@ export async function getDefaultUser(): Promise<User | null> {
  * @returns True if single-user mode, false otherwise
  */
 export function isSingleUserMode(): boolean {
-  const mode = process.env.FOVEA_MODE || 'multi-user'
-  return mode === 'single-user'
+  return config.mode.isSingleUser
 }

--- a/server/src/services/video-access-service.ts
+++ b/server/src/services/video-access-service.ts
@@ -7,6 +7,8 @@
 import { PrismaClient } from '@prisma/client'
 import { trace } from '@opentelemetry/api'
 
+import { isDemoModeEnabled } from '../lib/demo-flags.js'
+
 const tracer = trace.getTracer('fovea-rbac')
 
 /**
@@ -77,7 +79,7 @@ export class VideoAccessService {
     // mounts. This is gated on FOVEA_DEMO_MODE so a self-hosted
     // production deployment with the same code keeps its per-user
     // RBAC intact.
-    if (process.env.FOVEA_DEMO_MODE === 'true') {
+    if (isDemoModeEnabled()) {
       span.setAttribute('video_access.result_count', -1)
       span.setAttribute('video_access.demo_mode_override', true)
       span.end()

--- a/server/src/services/videoStorage.ts
+++ b/server/src/services/videoStorage.ts
@@ -13,6 +13,8 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { readFile } from 'fs/promises';
 
+import { config as appConfig } from '../config.js';
+
 /**
  * Video Storage Provider Interface
  *
@@ -927,50 +929,49 @@ class HybridStorageProvider implements VideoStorageProvider {
  * Load storage configuration from environment variables
  */
 export function loadStorageConfig(): VideoStorageConfig {
-  const storageType = (process.env.VIDEO_STORAGE_TYPE || 'local') as
+  const storageType = appConfig.storage.videoStorageType as
     | 'local'
     | 's3'
     | 'hybrid';
 
   const config: VideoStorageConfig = {
     type: storageType,
-    localPath: process.env.STORAGE_PATH || '/videos',
-    baseUrl: process.env.VIDEO_BASE_URL || '/api/videos',
+    localPath: appConfig.storage.path,
+    baseUrl: appConfig.storage.videoBaseUrl,
   };
 
   // S3 configuration
   if (storageType === 's3' || storageType === 'hybrid') {
     // In test environment, allow missing S3 credentials
     // Tests should mock storage operations or provide test credentials
-    if (process.env.NODE_ENV !== 'test' && (!process.env.S3_BUCKET || !process.env.S3_REGION)) {
+    if (!appConfig.server.isTest && (!appConfig.storage.s3.bucket || !appConfig.storage.s3.region)) {
       throw new Error('S3_BUCKET and S3_REGION are required for S3 storage');
     }
 
     config.s3 = {
-      bucket: process.env.S3_BUCKET || 'test-bucket',
-      region: process.env.S3_REGION || 'us-east-1',
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || process.env.S3_SECRET_ACCESS_KEY,
-      endpoint: process.env.S3_ENDPOINT,
-      publicBucket: process.env.S3_PUBLIC_BUCKET === 'true',
+      bucket: appConfig.storage.s3.bucket || 'test-bucket',
+      region: appConfig.storage.s3.region || 'us-east-1',
+      accessKeyId: appConfig.storage.s3.accessKeyId,
+      secretAccessKey: appConfig.storage.s3.secretAccessKey,
+      endpoint: appConfig.storage.s3.endpoint,
+      publicBucket: appConfig.storage.s3.publicBucket,
     };
   }
 
   // CDN configuration
-  if (process.env.CDN_ENABLED === 'true') {
+  if (appConfig.storage.cdn.enabled) {
     config.cdn = {
       enabled: true,
-      baseUrl: process.env.CDN_BASE_URL || '',
-      signedUrls: process.env.CDN_SIGNED_URLS !== 'false',
+      baseUrl: appConfig.storage.cdn.baseUrl,
+      signedUrls: appConfig.storage.cdn.signedUrls,
     };
   }
 
   // Thumbnail storage configuration
   config.thumbnails = {
-    storageType:
-      (process.env.THUMBNAIL_STORAGE_TYPE as 'local' | 's3') || 'local',
-    localPath: process.env.THUMBNAIL_PATH || '/videos/thumbnails',
-    s3Prefix: process.env.THUMBNAIL_S3_PREFIX || 'thumbnails/',
+    storageType: appConfig.storage.thumbnails.storageType as 'local' | 's3',
+    localPath: appConfig.storage.thumbnails.path,
+    s3Prefix: appConfig.storage.thumbnails.s3Prefix,
   };
 
   return config;

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -13,6 +13,8 @@ import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 import { resourceFromAttributes, defaultResource } from '@opentelemetry/resources'
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
 
+import { config } from './config.js'
+
 /**
  * Initializes OpenTelemetry SDK with trace and metric exporters.
  *
@@ -30,7 +32,7 @@ function initializeOpenTelemetry(): NodeSDK {
   );
 
   // Build full OTLP endpoint URLs
-  const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318';
+  const otlpEndpoint = config.otel.exporterEndpoint;
   const traceUrl = `${otlpEndpoint}/v1/traces`;
   const metricUrl = `${otlpEndpoint}/v1/metrics`;
 

--- a/server/test/services/videoStorage.test.ts
+++ b/server/test/services/videoStorage.test.ts
@@ -162,7 +162,9 @@ describe('Video Storage Providers', () => {
       const config = loadStorageConfig()
 
       expect(config.type).toBe('local')
-      expect(config.localPath).toBe('/videos')
+      // STORAGE_PATH unset falls back to the unified repo-relative default
+      // (<repo>/videos), an absolute path ending in `videos`.
+      expect(config.localPath).toMatch(/[/\\]videos$/)
       expect(config.baseUrl).toBe('/api/videos')
     })
 

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -1,18 +1,20 @@
-import { beforeAll, afterAll, afterEach, vi } from 'vitest'
+import { afterAll, afterEach, vi } from 'vitest'
 
 /**
  * Global test setup for backend tests.
  * This file is run before all tests via vitest.config.ts setupFiles.
+ *
+ * The base environment is set at module-eval (not inside `beforeAll`) so
+ * that the central config module sees a valid API_KEY_ENCRYPTION_KEY and
+ * test NODE_ENV the moment any test file imports something that loads
+ * `src/config.ts`. A `beforeAll` would run after the test file's static
+ * imports have already evaluated config and tripped its fail-fast check.
  */
-
-beforeAll(() => {
-  // Set test environment variables
-  process.env.NODE_ENV = 'test'
-  process.env.FOVEA_MODE = 'multi-user'
-  process.env.MODEL_SERVICE_URL = 'http://localhost:8000'
-  process.env.API_KEY_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-  process.env.SESSION_SECRET = 'test-session-secret-min-32-chars!!'
-})
+process.env.NODE_ENV = 'test'
+process.env.FOVEA_MODE = 'multi-user'
+process.env.MODEL_SERVICE_URL = 'http://localhost:8000'
+process.env.API_KEY_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+process.env.SESSION_SECRET = 'test-session-secret-min-32-chars!!'
 
 afterEach(() => {
   // Clear all mocks after each test

--- a/wikibase/pyproject.toml
+++ b/wikibase/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fovea-wikibase-loader"
-version = "0.4.4"
+version = "0.5.0"
 description = "Data loader for importing Wikidata into local Wikibase instances"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Description

**Phase 1a of the architecture-modularization roadmap** (`notes/architecture-review.md`) — the first sub-PR of the Configuration single-source-of-truth phase. It introduces one typed, validated, fail-fast config module for the backend and routes every environment read through it. This also opens the `0.5.0` release cycle (version bumped once here; later Phase 1–4 sub-PRs accumulate on `release/0.5.x` and ship together as 0.5.0).

Subsequent Phase 1 sub-PRs (separate): 1b `deploymentMode` object + demo-gating middleware, 1c frontend `config.ts`, 1d model-service `pydantic-settings`, 1e env-file collapse + generated `.env.example` + CI drift check.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

No tracking issue — roadmap-driven (`notes/architecture-review.md`, Phase 1). Naturally folds in the configurable-rate-limit half of upstream issue #05 (the `RATE_LIMIT_MAX`/`RATE_LIMIT_WINDOW` knobs now route through `config.rateLimit`).

## Changes Made

- New `server/src/config.ts`: the only file in `server/src` permitted to read `process.env`. Deep-frozen `config` object grouped by concern; loads optional local `.env` via `dotenv`; centralizes every default and coercion; exposes typed helpers `config.modelService.timeoutMs(endpoint)` and `config.getProviderApiKey(provider)` for the two dynamic read patterns.
- Migrated all 31 scattered `process.env` reads across routes/services/queues/middleware/libs to `config`. Added an ESLint `no-restricted-syntax` ban on `process.env` outside `config.ts` (with `prisma`/`test` exemptions) — lint passes with `--max-warnings 0`, proving the ban holds.
- Fail-fast startup: `config.ts` imported first in `index.ts` (before tracing); validates numeric env via TypeBox; requires `API_KEY_ENCRYPTION_KEY` to hex-decode to 32 bytes at boot (was validated lazily at first key use); refuses unset/dev-default `SESSION_SECRET` in production.
- Unified four defaults that disagreed across read sites — `STORAGE_PATH`, `FOVEA_MODE` (→ `multi-user`), `MODEL_SERVICE_URL` (→ `http://localhost:8000`), `OTEL_EXPORTER_OTLP_ENDPOINT` (→ `http://localhost:4318`). These only fire when the var is unset (local dev); docker/prod set them, so deployed behavior is unchanged.
- Bumped all seven package manifests to `0.5.0`; added the accumulating `## [0.5.0]` section to both changelogs.

## Testing

### Test Environment

- OS: macOS (Darwin 24.6.0)
- Browser (if applicable): N/A
- Node version: 22
- Python version (if applicable): N/A

### Test Cases

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. `pnpm --filter @fovea/server exec tsc --noEmit` → passes.
2. `pnpm --filter @fovea/server lint` → passes with 0 warnings (confirms no `process.env` outside `config.ts`).
3. `pnpm --filter @fovea/server build` → passes.
4. Full backend suite `pnpm --filter @fovea/server test -- --run` → **1205 tests passed (68 files)** with Postgres + Redis available (only the LocalStack-gated S3 hybrid suite self-skips).
5. Negative check: unset `API_KEY_ENCRYPTION_KEY` and import `config` → throws at startup.

## Screenshots/Videos

N/A — no UI changes.

## Documentation

- [x] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: Leaf config values are lazy getters that re-read `process.env` (preserving the prior lazy semantics and test mutability); env access is not a hot path.

## Breaking Changes

<!-- If this PR includes breaking changes, list them here with migration instructions -->

**Breaking changes:**
- Startup is now strict: a deployment missing `API_KEY_ENCRYPTION_KEY` (or with a wrong-length key), or running in production with an unset/dev-default `SESSION_SECRET`, now **fails fast at boot** instead of limping until first key use. Correctly-configured deployments are unaffected.

**Migration guide:**
- Ensure `API_KEY_ENCRYPTION_KEY` is set to a 32-byte hex value and `SESSION_SECRET` is a non-default value in production (both already required by `.env.example`). No code changes for consumers.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Design note: leaf values are lazy getters rather than a one-time snapshot, because several backend test suites mutate env then rebuild the app per case. This keeps a single source of truth (one module owns env) while exactly preserving the prior lazy `process.env.X || default` semantics; the fail-fast validation still runs once at module load.

## Reviewer Guidance

Start with `server/src/config.ts` (the schema, defaults, and the four documented unifications) and `server/.eslintrc.json` (the ban). The migrations are mechanical replacements of `process.env.X || default` with `config.*`; the only intentional behavior changes are the four unset-defaults and the fail-fast startup, both documented above.
