### PR TITLE
refactor: config drift guard + deploymentMode summary + config docs (Phase 1d, completes Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ FOVEA_MODE=multi-user
 ALLOW_REGISTRATION=false
 SESSION_SECRET=your-secret-key-here-min-32-chars-use-openssl-rand-base64-32
 SESSION_TIMEOUT_DAYS=7
+# Idle-session expiry in minutes (default 60).
+# SESSION_IDLE_TIMEOUT_MINUTES=60
+# Test-only: allow an admin-bypass header. Never enable in production.
+# ALLOW_TEST_ADMIN_BYPASS=false
+
+# Single-user mode identity (used only when FOVEA_MODE=single-user)
+# DEFAULT_USER_USERNAME=default-user
+# DEFAULT_USER_DISPLAY_NAME=Default User
 
 # Admin User Configuration (REQUIRED for multi-user mode)
 # This password is used when seeding the database to create the admin account
@@ -51,6 +59,9 @@ VITE_MODEL_SERVICE_URL=http://model-service:8000
 # Model Service Configuration
 TRANSFORMERS_CACHE=/models
 MODEL_CONFIG_PATH=/config/models.yaml
+# Shared secret guarding the model-service admin reconfigure endpoint. When unset,
+# the backend skips runtime model-service reconfiguration.
+# MODEL_SERVICE_ADMIN_TOKEN=your-admin-token
 CUDA_VISIBLE_DEVICES=0,1,2,3  # Adjust based on available GPUs
 PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
 
@@ -70,6 +81,9 @@ VIDEO_BASE_URL=/api/videos
 # S3_REGION=us-east-1
 # S3_ACCESS_KEY_ID=your-access-key-id
 # S3_SECRET_ACCESS_KEY=your-secret-access-key
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY take precedence over the S3_-prefixed pair when both are set.
+# AWS_ACCESS_KEY_ID=your-access-key-id
+# AWS_SECRET_ACCESS_KEY=your-secret-access-key
 # S3_ENDPOINT=                          # Optional: for S3-compatible services (MinIO, DigitalOcean Spaces, etc.)
 # S3_PUBLIC_BUCKET=false                # Set to true if bucket allows public reads (not recommended)
 
@@ -102,6 +116,19 @@ WIKIDATA_MODE=online
 # Specific controls (override master switch when set)
 # ALLOW_EXTERNAL_WIKIDATA_LINKS=true    # Controls Wikidata entity page links
 # ALLOW_EXTERNAL_VIDEO_SOURCE_LINKS=true # Controls video source links (uploaderUrl, webpageUrl)
+
+# Demo / Public-Booth Deployment (optional; off by default)
+# FOVEA_DEMO_MODE enables the demo layer (anonymous sessions, seeded corpus, tour endpoints).
+# FOVEA_DEMO_MODE=false
+# Allow anonymous (no-login) sessions; requires FOVEA_DEMO_MODE.
+# FOVEA_DEMO_ALLOW_ANONYMOUS_AUTH=false
+# Shared seeder secret (must be at least 32 chars to take effect).
+# FOVEA_DEMO_SEED_TOKEN=
+# Paths the demo seeder reads (defaults resolve under annotation-tool/demo).
+# FOVEA_DEMO_CLIPS_MANIFEST=
+# FOVEA_DEMO_FIXTURES_DIR=
+# Directory of custom guided-tour definitions.
+# FOVEA_TOURS_DIR=
 
 # Port Configuration (host ports)
 # REDIS_PORT is defined once in the Redis Configuration section above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Type check
         run: pnpm --filter @fovea/server exec tsc --noEmit
 
+      - name: Check .env.example covers backend config (no drift, no duplicate keys)
+        run: pnpm run check:env
+
   test-backend:
     name: Backend / Unit Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 - The model-service now reads every environment variable through one typed `Settings(BaseSettings)` in `model-service/src/infrastructure/config/settings.py` (`pydantic-settings`), validated once and instantiated at the top of the FastAPI `lifespan` so an invalid environment fails fast at startup. All 13 scattered `os.environ`/`os.getenv` reads across the routes, services, adapters, and observability layers now route through it; a guard test asserts no env read remains outside the settings module. The existing `models.yaml` discriminated-union catalog validation is unchanged - `Settings` only resolves which catalog to load and feeds the DI container, subsuming the two previously-divergent `MODEL_CONFIG_PATH` resolution sites into one.
 - The dynamic `<PROVIDER>_API_KEY` lookup becomes a typed `Settings.get_provider_api_key(provider)` helper, the `HUGGING_FACE_HUB_TOKEN`/`HF_TOKEN` pair becomes one alias-choice field, and the single `OTEL_EXPORTER_OTLP_ENDPOINT` fans out to the traces and metrics endpoints through derived properties that preserve the prior two-default behavior exactly.
 
+#### Configuration Drift Guard and Deployment-Mode Summary
+
+- A CI guard (`pnpm check:env`, run in the backend lint job) fails the build when `.env.example` declares a duplicate key or omits any variable the backend config module reads, so the committed template cannot silently drift from the code. `.env.example` is brought into sync: the previously-undocumented `SESSION_IDLE_TIMEOUT_MINUTES`, `ALLOW_TEST_ADMIN_BYPASS`, `DEFAULT_USER_USERNAME`/`DEFAULT_USER_DISPLAY_NAME`, `MODEL_SERVICE_ADMIN_TOKEN`, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, and the demo/tours variables are now documented (as commented optional entries).
+- The backend resolves its mode and demo flags into one derived `config.deploymentMode` object (typed `auth` and `demo`) and logs a one-line summary at startup (for example `[config] deployment mode: auth=multi-user demo=off`). A new operations guide (`docs/docs/operations/configuration.md`) documents the configuration model, fail-fast startup, and the deployment-mode taxonomy across all three services.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases

--- a/docs/docs/operations/configuration.md
+++ b/docs/docs/operations/configuration.md
@@ -1,0 +1,73 @@
+# Configuration
+
+Every Fovea service reads its environment through a single typed
+configuration module, validated once at startup. This is the one place
+each service answers the question "what does this deployment do when a
+variable is unset?", so an operator never has to trace a setting through
+scattered reads.
+
+## Where configuration lives
+
+| Service | Config module | Reads from |
+| --- | --- | --- |
+| Backend | `server/src/config.ts` | `process.env` (optionally a local `.env`) |
+| Frontend | `annotation-tool/src/config.ts` | `import.meta.env` (build-time) |
+| Model service | `model-service/src/infrastructure/config/settings.py` | `os.environ` (optionally a local `.env`) |
+
+Each module is the **only** file in its service permitted to read the
+environment. The backend and frontend enforce this with an ESLint rule,
+and the model service with a guard test. New configuration must be added
+to the module, not read inline somewhere else.
+
+The committed template `.env.example` is the canonical list of supported
+variables. A CI check (`pnpm check:env`) fails the build if `.env.example`
+contains a duplicate key or omits any key the backend config module reads,
+so the template can never silently drift from the code.
+
+## Fail-fast startup
+
+Each service validates its configuration once, at process start, and
+refuses to boot on a fatal problem rather than failing later in a handler:
+
+- The backend imports `config.ts` first (before tracing), validates the
+  numeric variables, requires `API_KEY_ENCRYPTION_KEY` to decode to 32
+  bytes, and refuses an unset or default `SESSION_SECRET` in production.
+- The model service instantiates its `Settings` at the top of the FastAPI
+  lifespan.
+
+A misconfigured deployment therefore stops immediately with a clear error.
+
+## Deployment mode
+
+Two variables decide the high-level posture of a backend deployment:
+
+- `FOVEA_MODE` selects the authentication model: `multi-user` (login and
+  sessions, the secure default) or `single-user` (auto-login, no
+  passwords, for local development).
+- `FOVEA_DEMO_MODE` enables the demo layer (a seeded corpus and tour
+  endpoints). With `FOVEA_DEMO_ALLOW_ANONYMOUS_AUTH` it also permits
+  anonymous, no-login sessions for a public booth.
+
+The backend resolves these into one `config.deploymentMode` object with a
+typed `auth` (`single-user` | `multi-user`) and `demo` (`off` | `on` |
+`public`), and logs a one-line summary at startup, for example:
+
+```
+[config] deployment mode: auth=multi-user demo=off
+```
+
+Check that line first when a deployment behaves unexpectedly: it reports
+exactly which mode the resolved configuration produced.
+
+The frontend mirrors this with its own `config.deploymentMode`, whose
+`kind` is one of `normal`, `public-demo`, `tour-demo`, or
+`legacy-demo-shell`, derived from the `VITE_DEMO_PUBLIC`, `VITE_TOUR_DEMO`,
+and `VITE_FOVEA_DEMO_MODE` build flags.
+
+## Reference
+
+See `.env.example` for the full, commented list of variables with their
+defaults. Storage, S3, CDN, Wikidata, external-link, and demo options are
+shipped commented-out because they are optional; uncomment and set them
+for deployments that need them. Host-port mappings live in the
+`Port Configuration` section at the end of the file.

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -33,6 +33,11 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 - The model-service now reads every environment variable through one typed `Settings(BaseSettings)` in `model-service/src/infrastructure/config/settings.py` (`pydantic-settings`), validated once and instantiated at the top of the FastAPI `lifespan` so an invalid environment fails fast at startup. All 13 scattered `os.environ`/`os.getenv` reads across the routes, services, adapters, and observability layers now route through it; a guard test asserts no env read remains outside the settings module. The existing `models.yaml` discriminated-union catalog validation is unchanged - `Settings` only resolves which catalog to load and feeds the DI container, subsuming the two previously-divergent `MODEL_CONFIG_PATH` resolution sites into one.
 - The dynamic `<PROVIDER>_API_KEY` lookup becomes a typed `Settings.get_provider_api_key(provider)` helper, the `HUGGING_FACE_HUB_TOKEN`/`HF_TOKEN` pair becomes one alias-choice field, and the single `OTEL_EXPORTER_OTLP_ENDPOINT` fans out to the traces and metrics endpoints through derived properties that preserve the prior two-default behavior exactly.
 
+#### Configuration Drift Guard and Deployment-Mode Summary
+
+- A CI guard (`pnpm check:env`, run in the backend lint job) fails the build when `.env.example` declares a duplicate key or omits any variable the backend config module reads, so the committed template cannot silently drift from the code. `.env.example` is brought into sync: the previously-undocumented `SESSION_IDLE_TIMEOUT_MINUTES`, `ALLOW_TEST_ADMIN_BYPASS`, `DEFAULT_USER_USERNAME`/`DEFAULT_USER_DISPLAY_NAME`, `MODEL_SERVICE_ADMIN_TOKEN`, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, and the demo/tours variables are now documented (as commented optional entries).
+- The backend resolves its mode and demo flags into one derived `config.deploymentMode` object (typed `auth` and `demo`) and logs a one-line summary at startup (for example `[config] deployment mode: auth=multi-user demo=off`). A new operations guide (`docs/docs/operations/configuration.md`) documents the configuration model, fail-fast startup, and the deployment-mode taxonomy across all three services.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -90,6 +90,7 @@ const sidebars: SidebarsConfig = {
       link: {type: 'doc', id: 'operations/index'},
       items: [
         'operations/production-deployment',
+        'operations/configuration',
         'operations/demo-fovea-deployment',
         'operations/monitoring',
         'operations/backup-restore',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:backend": "pnpm run --filter @fovea/server test",
     "lint": "pnpm run --filter @fovea/annotation-tool lint && pnpm run --filter @fovea/server lint",
     "type-check": "pnpm run --filter @fovea/annotation-tool type-check",
+    "check:env": "node scripts/check-env-example.mjs",
     "stop": "docker compose -f server/docker-compose.dev.yml down",
     "clean": "docker compose -f server/docker-compose.dev.yml down -v"
   },

--- a/scripts/check-env-example.mjs
+++ b/scripts/check-env-example.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Configuration drift guard for `.env.example`.
+ *
+ * Enforces two invariants so the committed environment template cannot
+ * silently diverge from what the code actually reads:
+ *
+ *   1. `.env.example` declares no key twice. Duplicate dotenv keys are
+ *      silently last-wins, which previously hid a real foot-gun.
+ *   2. Every environment variable the backend config module reads through
+ *      its declarative `readString`/`readInt`/`readBoolean*` helpers
+ *      (`server/src/config.ts`) is present in `.env.example`. Adding a new
+ *      backend config key without documenting it in the template now fails
+ *      CI rather than shipping an under-specified template.
+ *
+ * The dynamic reads in `config.ts` (the `MODEL_SERVICE_TIMEOUT_<NAME>_MS`
+ * family and the `<PROVIDER>_API_KEY` lookup) are intentionally not part of
+ * invariant 2 because they are optional and not enumerable as literals.
+ *
+ * Run via `pnpm check:env` (or directly with node). Exits non-zero on any
+ * violation with a precise, actionable message.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const envExamplePath = join(repoRoot, '.env.example')
+const configPath = join(repoRoot, 'server', 'src', 'config.ts')
+
+/**
+ * Parse `.env.example` keys.
+ *
+ * Returns the active keys (uncommented `KEY=` lines, in order, for the
+ * duplicate check) and the documented keys (active plus commented
+ * `# KEY=` lines, for the coverage check). A commented entry is treated
+ * as documentation: optional vars like the S3/CDN block are intentionally
+ * shipped commented-out, and that still tells an operator the key exists.
+ */
+function parseEnvKeys(text) {
+  const active = []
+  const documented = new Set()
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim()
+    if (line === '') continue
+    const activeMatch = /^([A-Z_][A-Z0-9_]*)=/.exec(line)
+    if (activeMatch) {
+      active.push(activeMatch[1])
+      documented.add(activeMatch[1])
+      continue
+    }
+    const commentedMatch = /^#\s*([A-Z_][A-Z0-9_]*)=/.exec(line)
+    if (commentedMatch) documented.add(commentedMatch[1])
+  }
+  return { active, documented }
+}
+
+/** Env var names read through the declarative `readX('NAME', ...)` helpers. */
+function backendConfigKeys(text) {
+  const keys = new Set()
+  const pattern =
+    /read(?:String|StringWithDefault|Int|BooleanStrictTrue|BooleanTrueOrOne|BooleanDefaultTrue)\(\s*'([A-Z_][A-Z0-9_]*)'/g
+  let m
+  while ((m = pattern.exec(text)) !== null) keys.add(m[1])
+  return keys
+}
+
+const errors = []
+
+const { active, documented } = parseEnvKeys(readFileSync(envExamplePath, 'utf8'))
+
+// Invariant 1: no duplicate active keys.
+const seen = new Set()
+const duplicates = new Set()
+for (const key of active) {
+  if (seen.has(key)) duplicates.add(key)
+  seen.add(key)
+}
+if (duplicates.size > 0) {
+  errors.push(
+    `.env.example declares these keys more than once (duplicate dotenv keys are silently last-wins): ${[...duplicates].sort().join(', ')}`,
+  )
+}
+
+// Invariant 2: every declarative backend config key is documented (active or commented).
+const configKeys = backendConfigKeys(readFileSync(configPath, 'utf8'))
+const missing = [...configKeys].filter((k) => !documented.has(k)).sort()
+if (missing.length > 0) {
+  errors.push(
+    `server/src/config.ts reads these keys but .env.example does not document them: ${missing.join(', ')}\n` +
+      `  Add them to .env.example (active or commented, with a comment) so the template stays in sync.`,
+  )
+}
+
+if (errors.length > 0) {
+  console.error('Configuration drift check FAILED:\n')
+  for (const e of errors) console.error(`  - ${e}\n`)
+  process.exit(1)
+}
+
+console.log(
+  `Configuration drift check passed: ${active.length} active keys in .env.example, ` +
+    `all ${configKeys.size} declarative backend config keys documented, no duplicates.`,
+)

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -256,6 +256,23 @@ function resolveTimeoutMs(endpoint: ModelServiceTimeoutEndpoint): number {
   return ms
 }
 
+/** Resolved authentication model for this deployment. */
+export type AuthMode = 'single-user' | 'multi-user'
+
+/** Resolved demo posture: `off`, `on` (seeded demo), or `public` (demo plus anonymous sessions). */
+export type DemoMode = 'off' | 'on' | 'public'
+
+function resolveAuthMode(): AuthMode {
+  return readStringWithDefault('FOVEA_MODE', DEFAULT_MODE) === 'single-user'
+    ? 'single-user'
+    : 'multi-user'
+}
+
+function resolveDemoMode(): DemoMode {
+  if (!readBooleanTrueOrOne('FOVEA_DEMO_MODE')) return 'off'
+  return readBooleanTrueOrOne('FOVEA_DEMO_ALLOW_ANONYMOUS_AUTH') ? 'public' : 'on'
+}
+
 const config = Object.freeze({
   server: Object.freeze({
     get port(): number {
@@ -424,6 +441,24 @@ const config = Object.freeze({
     },
     get isSingleUser(): boolean {
       return readStringWithDefault('FOVEA_MODE', DEFAULT_MODE) === 'single-user'
+    },
+  }),
+
+  /**
+   * One derived object resolving every mode/demo flag into the deployment's
+   * posture, so an admin can read "what kind of deployment is this" from one
+   * place instead of cross-referencing scattered flags. Logged once at startup.
+   */
+  deploymentMode: Object.freeze({
+    get auth(): AuthMode {
+      return resolveAuthMode()
+    },
+    get demo(): DemoMode {
+      return resolveDemoMode()
+    },
+    /** Compact human-readable summary, e.g. `auth=multi-user demo=off`. */
+    get summary(): string {
+      return `auth=${resolveAuthMode()} demo=${resolveDemoMode()}`
     },
   }),
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -139,6 +139,8 @@ async function start() {
   const app = await buildApp()
   const PORT = config.server.port
 
+  app.log.info(`[config] deployment mode: ${config.deploymentMode.summary}`)
+
   try {
     await connectDatabase()
     await initializeDataDirectory()


### PR DESCRIPTION
## Description

**Phase 1d — the final sub-PR of the Configuration single-source-of-truth phase.** Adds the CI guard that keeps `.env.example` in sync with the code, resolves the backend mode/demo flags into one derived `deploymentMode` summary (logged at startup), and documents the configuration model. With this, **Phase 1 (Configuration SSoT) is complete**. Part of the accumulating `0.5.0` cycle on `release/0.5.x` (no version bump).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Build/infrastructure changes

## Related Issues

No tracking issue — roadmap-driven (`notes/architecture-review.md`, Phase 1).

## Changes Made

- New `scripts/check-env-example.mjs` (run as `pnpm check:env`, wired into the gated `Backend / Lint` job): fails CI if `.env.example` declares a duplicate key, or omits any variable the backend config module reads through its declarative helpers. Commented entries count as documented (optional vars ship commented-out); dynamic keys (the timeout family, provider keys) are intentionally out of scope.
- Brought `.env.example` into sync: documented the 12 previously-absent backend keys (`SESSION_IDLE_TIMEOUT_MINUTES`, `ALLOW_TEST_ADMIN_BYPASS`, `DEFAULT_USER_USERNAME`/`DEFAULT_USER_DISPLAY_NAME`, `MODEL_SERVICE_ADMIN_TOKEN`, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, and the demo/tours variables) as commented optional entries grouped by concern.
- Added a derived `config.deploymentMode` (`{ auth, demo, summary }`) to the backend config and a one-line startup log (`[config] deployment mode: auth=multi-user demo=off`).
- New `docs/docs/operations/configuration.md` (+ sidebar entry) documenting the SSoT model, fail-fast startup, and the deployment-mode taxonomy across all three services.

## Testing

### Test Environment

- OS: macOS (Darwin 24.6.0)
- Node version: 22

### Test Cases

- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. `pnpm check:env` → passes (43 active keys, all 47 declarative backend keys documented, no duplicates). Negative-tested: adding a duplicate key or an undocumented config read makes it exit non-zero.
2. `pnpm --filter @fovea/server exec tsc --noEmit` and `lint` → pass.
3. `vitest run config` → 32 tests pass with the new `deploymentMode`.

## Screenshots/Videos

N/A.

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [x] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: The drift check is a fast node script in the lint job; `deploymentMode` is derived lazily.

## Breaking Changes

**Breaking changes:**
- None.

**Migration guide:**
- N/A. `.env.example` gains documentation only (new entries are commented-out optional vars).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Deferred (noted in the roadmap, low value): relocating the reference `.env.demo`/`.env.hybrid`/`.env.s3` files — verified they are wired into nothing, so collapsing them is cosmetic and risks breaking muscle-memory workflows.

## Reviewer Guidance

Start with `scripts/check-env-example.mjs` (the two invariants) and the `.env.example` additions. The `config.deploymentMode` getters and the `index.ts` startup log are small and additive.
