### PR TITLE
build: validate all 10 compose files in CI + fix model-service thumbnail path (Phase 2b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,28 @@ jobs:
           retention-days: 30
 
   # Quality gate - all checks must pass
+  verify-compose:
+    name: Compose / Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate every docker compose configuration
+        run: |
+          set -euo pipefail
+          echo "Validating all compose files with their documented -f override chains..."
+          docker compose -f docker-compose.yml config --quiet
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet
+          docker compose -f docker-compose.yml -f docker-compose.tour-demo.yml config --quiet
+          docker compose -f docker-compose.yml -f docker-compose.tour-demo.yml -f docker-compose.demo.yml config --quiet
+          docker compose -f docker-compose.yml -f docker-compose.local-full.yml config --quiet
+          docker compose -f docker-compose.e2e.yml config --quiet
+          docker compose -f docker-compose.e2e.yml -f docker-compose.e2e.real-models.yml --profile with-models config --quiet
+          docker compose -f docker-compose.wikibase.yml config --quiet
+          docker compose -f server/docker-compose.dev.yml config --quiet
+          docker compose -f server/docker-compose.test.yml config --quiet
+          echo "All 10 compose configurations are valid."
+
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
@@ -443,6 +465,7 @@ jobs:
       - lint-model-service
       - lint-wikibase
       - test-wikibase
+      - verify-compose
       # - test-e2e  # disabled (job has if: false; gate must not require it)
       # test-model-service disabled due to disk space constraints
     if: always()
@@ -470,6 +493,9 @@ jobs:
             echo "- Lint: ${{ needs.lint-wikibase.result }}"
             echo "- Tests: ${{ needs.test-wikibase.result }}"
             echo ""
+            echo "### Compose"
+            echo "- Validate: ${{ needs.verify-compose.result }}"
+            echo ""
             echo "### Integration"
             # echo "- E2E Tests: ${{ needs.test-e2e.result }}" — disabled
           } >> "$GITHUB_STEP_SUMMARY"
@@ -484,6 +510,7 @@ jobs:
           LINT_MODEL="${{ needs.lint-model-service.result }}"
           LINT_WIKIBASE="${{ needs.lint-wikibase.result }}"
           TEST_WIKIBASE="${{ needs.test-wikibase.result }}"
+          VERIFY_COMPOSE="${{ needs.verify-compose.result }}"
           # TEST_E2E="${{ needs.test-e2e.result }}"  # disabled
 
           if [ "$LINT_FRONTEND" != "success" ] || \
@@ -494,7 +521,8 @@ jobs:
              [ "$BUILD_BACKEND" != "success" ] || \
              [ "$LINT_MODEL" != "success" ] || \
              [ "$LINT_WIKIBASE" != "success" ] || \
-             [ "$TEST_WIKIBASE" != "success" ]; then  # E2E disabled
+             [ "$TEST_WIKIBASE" != "success" ] || \
+             [ "$VERIFY_COMPOSE" != "success" ]; then  # E2E disabled
             {
               echo ""
               echo "❌ Quality gate FAILED"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -194,19 +194,5 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64
 
-  verify-compose:
-    name: Verify Docker Compose
-    runs-on: ubuntu-latest
-    needs: [build-frontend, build-backend, build-model-service, build-wikibase-loader]
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Validate docker-compose.yml
-        run: docker compose config --quiet
-
-      - name: Check compose file syntax
-        run: docker compose config > /dev/null
-
-      - name: Validate wikibase compose file
-        run: docker compose -f docker-compose.wikibase.yml config --quiet
+# Compose validation moved to ci.yml's `verify-compose` job, which validates
+# all 10 compose files (with their override chains) and runs on release/** too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,19 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 - Node and pnpm versions are now pinned in exactly one place. A root `.nvmrc` (Node `22`) and the root `package.json` `packageManager` field (`pnpm@10.15.0`, plus `engines.node >=22`) are the single sources: every Dockerfile takes `ARG NODE_VERSION` and every CI workflow reads `node-version-file: .nvmrc` and resolves pnpm from `packageManager` (the per-workflow `pnpm/action-setup` `version` pins and the `NODE_VERSION` env vars are removed). This closes the prior split where the production images ran Node 20 + pnpm 10.15.0 while every CI workflow ran Node 22 + pnpm 9, and fixes a stray Node 20 in the deploy workflow. The converged Node 22 images were validated by building them locally (the backend image runs Node 22 with its native modules and Prisma client intact).
 
+#### CI Validates All Compose Configurations
+
+- A new `verify-compose` CI job validates all ten docker compose configurations (each with its documented `-f` override chain and profile) on every relevant PR, replacing the prior check that covered only two of them. It catches structural drift, such as an overlay referencing a service its base does not define, before it reaches a deploy.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases
 
 - `release.yml` gains a `create-release` job that, on every `v*.*.*` tag push, extracts the matching `CHANGELOG.md` section and creates or updates the GitHub Release. Previously the workflow only built and pushed Docker images, so a tag published no GitHub Release unless one was made by hand (which is how v0.4.3's Release came to be missing). The job is deliberately independent of the image build, so a Release is published even when the heavy `model-service-gpu` image hits the 90-minute job timeout.
+
+#### Model-Service Thumbnails Written to a Container-Local Path
+
+- The `model-service` and `model-service-gpu` services in `docker-compose.yml` now set `THUMBNAIL_OUTPUT_ROOT` (following the backend's `THUMBNAIL_PATH`, default `/videos/thumbnails`) into the shared `/videos` mount. Previously the model-service defaulted to its container-local `/tmp/thumbnails`, so generated thumbnails landed where the backend could never read them.
 
 ## [0.4.4] - 2026-06-17
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,11 @@ services:
       - HF_TOKEN=${HF_TOKEN:-}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
       - MODEL_CONFIG_PATH=/config/models-cpu.yaml
+      # Write thumbnails into the shared /videos mount where the backend reads
+      # them (follows the backend's THUMBNAIL_PATH). Without this the model-service
+      # defaults to its container-local /tmp/thumbnails and the backend never
+      # finds them.
+      - THUMBNAIL_OUTPUT_ROOT=${THUMBNAIL_PATH:-/videos/thumbnails}
     volumes:
       - model-cache:/models
       - ./videos:/videos
@@ -172,6 +177,8 @@ services:
       - MODEL_CONFIG_PATH=/config/models.yaml
       - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-max_split_size_mb:512}
+      # Shared thumbnail output root (see the CPU model-service above).
+      - THUMBNAIL_OUTPUT_ROOT=${THUMBNAIL_PATH:-/videos/thumbnails}
     networks:
       fovea-network:
         aliases:

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -42,11 +42,19 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 - Node and pnpm versions are now pinned in exactly one place. A root `.nvmrc` (Node `22`) and the root `package.json` `packageManager` field (`pnpm@10.15.0`, plus `engines.node >=22`) are the single sources: every Dockerfile takes `ARG NODE_VERSION` and every CI workflow reads `node-version-file: .nvmrc` and resolves pnpm from `packageManager` (the per-workflow `pnpm/action-setup` `version` pins and the `NODE_VERSION` env vars are removed). This closes the prior split where the production images ran Node 20 + pnpm 10.15.0 while every CI workflow ran Node 22 + pnpm 9, and fixes a stray Node 20 in the deploy workflow. The converged Node 22 images were validated by building them locally (the backend image runs Node 22 with its native modules and Prisma client intact).
 
+#### CI Validates All Compose Configurations
+
+- A new `verify-compose` CI job validates all ten docker compose configurations (each with its documented `-f` override chain and profile) on every relevant PR, replacing the prior check that covered only two of them. It catches structural drift, such as an overlay referencing a service its base does not define, before it reaches a deploy.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases
 
 - `release.yml` gains a `create-release` job that, on every `v*.*.*` tag push, extracts the matching `CHANGELOG.md` section and creates or updates the GitHub Release. Previously the workflow only built and pushed Docker images, so a tag published no GitHub Release unless one was made by hand (which is how v0.4.3's Release came to be missing). The job is deliberately independent of the image build, so a Release is published even when the heavy `model-service-gpu` image hits the 90-minute job timeout.
+
+#### Model-Service Thumbnails Written to a Container-Local Path
+
+- The `model-service` and `model-service-gpu` services in `docker-compose.yml` now set `THUMBNAIL_OUTPUT_ROOT` (following the backend's `THUMBNAIL_PATH`, default `/videos/thumbnails`) into the shared `/videos` mount. Previously the model-service defaulted to its container-local `/tmp/thumbnails`, so generated thumbnails landed where the backend could never read them.
 
 ## [0.4.4] - 2026-06-17
 


### PR DESCRIPTION
## Description

**Phase 2b — CI compose validation + the model-service thumbnail-path fix** (folds in upstream issue #14). Expands compose validation from 2 of 10 files to all 10 (with their documented override chains), and closes the cross-container thumbnail contract gap. Part of the `0.5.0` cycle on `release/0.5.x`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

No GitHub tracking issue. Folds in the upstream "thumbnails written to container-local /tmp" report (`notes/fovea-issues/14`). Roadmap: `notes/architecture-review.md`, Phase 2.

## Changes Made

- New `verify-compose` job in `ci.yml` that validates **all ten** docker compose configurations, each with its documented `-f` override chain and profile (e.g. the e2e real-models stack with `--profile with-models`, the demo stack as `docker-compose.yml -f tour-demo -f demo`). Added to the quality gate. Removed the prior 2-file `verify-compose` from `docker.yml` (superseded; `ci.yml` runs on `release/**` too).
- `docker-compose.yml`: the `model-service` and `model-service-gpu` services now set `THUMBNAIL_OUTPUT_ROOT=${THUMBNAIL_PATH:-/videos/thumbnails}` — following the backend's `THUMBNAIL_PATH` into the shared `/videos` mount. Previously the model-service defaulted to its container-local `/tmp/thumbnails`, so the backend never found generated thumbnails.

## Testing

### Test Environment

- OS: macOS (Darwin 24.6.0); Docker 28.4.0 + compose v2

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Ran the exact `verify-compose` commands locally: **all 10 compose configurations validate** (`docker compose -f … config --quiet`). The validation also surfaced that the e2e real-models overlay requires `--profile with-models` (model-service is profile-gated) — encoded in the job.
2. `docker compose -f docker-compose.yml config` shows `THUMBNAIL_OUTPUT_ROOT: /videos/thumbnails` on both model-service services.

## Screenshots/Videos

N/A.

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: One fast compose-validation job; no runtime change beyond the added env var.

## Breaking Changes

**Breaking changes:**
- None. The thumbnail env var has a default that matches the backend; deployments that already set `THUMBNAIL_PATH` get it applied to the model-service automatically.

**Migration guide:**
- N/A.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Tag-pinning of the floating `:latest` observability images (otel-collector/prometheus/grafana/jaeger/localstack) is intentionally deferred to a separate, careful change — pinning the production base file's images requires verifying each version against its config, and is orthogonal to this PR.

## Reviewer Guidance

The `verify-compose` job lists every compose invocation explicitly (with the override chains and the one required profile). The `THUMBNAIL_OUTPUT_ROOT` addition mirrors the backend's `THUMBNAIL_PATH` so a single operator var drives both containers.
