### PR TITLE
build: add a root Makefile as the single build/test entrypoint, point docs at it (Phase 3b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ notes/
 model-service/uv.lock
 .demo-local/
 .demo-local-bringup.log
+
+# wikibase uses pip in CI; its uv.lock is a local `uv run` artifact, not committed
+wikibase/uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 - Deleted the duplicate `server/docker-compose.dev.yml`, which redefined Postgres, Redis, and the full observability stack with conflicting credentials (`user`/`password` versus the root stack's `fovea`/`fovea_password`) and a separate volume. The `dev:infra`, `dev:infra:full`, `stop`, and `clean` scripts now drive the root `docker-compose.yml` (plus its `dev` overlay for the observability services), so local development and the full stack share one Postgres definition and one set of credentials. Local dev databases that relied on the old `user`/`password` credentials must point their `DATABASE_URL` at the canonical `fovea`/`fovea_password` (matching `.env.example`).
 
+#### Unified Build and Test Entrypoint
+
+- A root `Makefile` is now the single source for the install/lint/typecheck/test/build recipe across all four components (Node via pnpm, Python via uv): `make lint`, `make typecheck`, `make test`, `make build`, plus per-suite targets such as `make test-model-service` (run `make help` to list them). The README and CONTRIBUTING guides point at it, replacing their previously-divergent per-package instructions, which had drifted between `npm` and `pnpm` and between bare `pytest` and `uv run pytest`.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,19 +140,15 @@ Before contributing, ensure you have:
    uvicorn src.main:app --reload --port 8000
    ```
 
-7. **Verify your setup** by running tests:
+7. **Verify your setup** by running tests through the root `Makefile` (the
+   single source for every build/lint/test recipe; run `make help` to list
+   targets):
    ```bash
-   # Frontend tests
-   cd annotation-tool
-   npm run test
-
-   # Backend tests
-   cd server
-   npm run test
-
-   # Model service tests
-   cd model-service
-   pytest
+   make test                 # every suite, or:
+   make test-frontend
+   make test-backend         # needs Postgres + Redis: make dev-infra
+   make test-model-service
+   make test-wikibase
    ```
 
 For detailed setup instructions, see the [Manual Setup Guide](docs/docs/getting-started/manual-setup.md).
@@ -294,27 +290,13 @@ git rebase --continue
 
 1. **Ensure all tests pass**:
    ```bash
-   # Run all test suites
-   cd annotation-tool && npm run test && npm run test:e2e
-   cd server && npm run test
-   cd model-service && pytest
+   make test
    ```
 
 2. **Check code quality**:
    ```bash
-   # Frontend
-   cd annotation-tool
-   npm run lint
-   npm run type-check
-
-   # Backend
-   cd server
-   npm run lint
-
-   # Model service
-   cd model-service
-   ruff check .
-   mypy src/
+   make lint
+   make typecheck
    ```
 
 3. **Update documentation** if you've changed APIs or added features

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,78 @@
+# Single entrypoint for installing, linting, type-checking, testing, and
+# building every Fovea component: the Node packages (frontend, backend) via
+# pnpm and the Python services (model-service, wikibase) via uv. CI mirrors
+# these recipes, and README / CONTRIBUTING / DOCKER_QUICK_REFERENCE point
+# here, so the build-and-test recipe lives in exactly one place.
+#
+# Run `make` or `make help` to list targets.
+
+.DEFAULT_GOAL := help
+.PHONY: help install generate \
+	lint lint-frontend lint-backend lint-model-service lint-wikibase \
+	typecheck test test-frontend test-backend test-model-service test-wikibase \
+	build dev-infra stop
+
+help: ## List available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install all dependencies (pnpm workspace + uv for the Python services)
+	pnpm install --frozen-lockfile
+	cd model-service && uv sync
+	cd wikibase && uv sync
+
+generate: ## Generate the Prisma client (needed before backend typecheck/test)
+	pnpm --filter @fovea/server exec prisma generate
+
+## --- Lint -----------------------------------------------------------------
+
+lint: lint-frontend lint-backend lint-model-service lint-wikibase ## Lint every component
+
+lint-frontend: ## Lint the frontend
+	pnpm --filter @fovea/annotation-tool lint
+
+lint-backend: ## Lint the backend and check the .env.example drift guard
+	pnpm --filter @fovea/server lint
+	pnpm run check:env
+
+lint-model-service: ## Lint the model-service (ruff check + format)
+	cd model-service && uv run ruff check . && uv run ruff format --check .
+
+lint-wikibase: ## Lint the wikibase loader (ruff check + format)
+	cd wikibase && uv run ruff check . && uv run ruff format --check .
+
+## --- Typecheck ------------------------------------------------------------
+
+typecheck: generate ## Type-check every component (tsc + mypy)
+	pnpm --filter @fovea/annotation-tool exec tsc --noEmit
+	pnpm --filter @fovea/server exec tsc --noEmit
+	cd model-service && uv run mypy src/
+	cd wikibase && uv run mypy scripts/
+
+## --- Test -----------------------------------------------------------------
+
+test: test-frontend test-backend test-model-service test-wikibase ## Run every test suite
+
+test-frontend: ## Frontend unit tests
+	pnpm --filter @fovea/annotation-tool test -- --run
+
+test-backend: generate ## Backend unit + integration tests (needs Postgres + Redis: `make dev-infra`)
+	pnpm --filter @fovea/server test -- --run
+
+test-model-service: ## Model-service tests (excludes heavy model downloads)
+	cd model-service && uv run pytest -m "not requires_models"
+
+test-wikibase: ## Wikibase loader tests
+	cd wikibase && uv run pytest
+
+## --- Build / dev ----------------------------------------------------------
+
+build: generate ## Build the frontend and backend
+	pnpm --filter @fovea/annotation-tool build
+	pnpm --filter @fovea/server build
+
+dev-infra: ## Start local Postgres + Redis (for backend dev/tests)
+	pnpm run dev:infra
+
+stop: ## Stop the local dev stack
+	pnpm run stop

--- a/README.md
+++ b/README.md
@@ -185,32 +185,22 @@ Includes hot-reload volumes, Jaeger tracing at [localhost:16686](http://localhos
 
 ### Running tests
 
-**Frontend:**
+All install, lint, type-check, test, and build recipes live in one place: the
+root `Makefile` (Node via pnpm, Python via uv). Run `make help` to list every
+target.
 
 ```bash
-cd annotation-tool
-npm run test              # Vitest unit tests
-npm run test:e2e          # Playwright E2E tests
-npm run lint              # ESLint
-npx tsc --noEmit          # Type check
+make install          # Install all dependencies (pnpm workspace + uv)
+make lint             # Lint every component
+make typecheck        # Type-check every component (tsc + mypy)
+make test             # Run every test suite
+make build            # Build the frontend and backend
 ```
 
-**Backend:**
-
-```bash
-cd server
-npm run test              # Vitest unit tests
-npm run lint              # ESLint
-```
-
-**Model Service:**
-
-```bash
-cd model-service
-uv run pytest             # Unit tests
-uv run ruff check src/    # Lint
-uv run mypy src/          # Type check
-```
+Per-suite targets are also available, e.g. `make test-frontend`,
+`make test-backend`, `make test-model-service`, `make test-wikibase` (and the
+matching `lint-*`). Backend tests need Postgres and Redis — start them first
+with `make dev-infra`.
 
 ### Monitoring
 

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -50,6 +50,10 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 - Deleted the duplicate `server/docker-compose.dev.yml`, which redefined Postgres, Redis, and the full observability stack with conflicting credentials (`user`/`password` versus the root stack's `fovea`/`fovea_password`) and a separate volume. The `dev:infra`, `dev:infra:full`, `stop`, and `clean` scripts now drive the root `docker-compose.yml` (plus its `dev` overlay for the observability services), so local development and the full stack share one Postgres definition and one set of credentials. Local dev databases that relied on the old `user`/`password` credentials must point their `DATABASE_URL` at the canonical `fovea`/`fovea_password` (matching `.env.example`).
 
+#### Unified Build and Test Entrypoint
+
+- A root `Makefile` is now the single source for the install/lint/typecheck/test/build recipe across all four components (Node via pnpm, Python via uv): `make lint`, `make typecheck`, `make test`, `make build`, plus per-suite targets such as `make test-model-service` (run `make help` to list them). The README and CONTRIBUTING guides point at it, replacing their previously-divergent per-package instructions, which had drifted between `npm` and `pnpm` and between bare `pytest` and `uv run pytest`.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases


### PR DESCRIPTION
## Description

**Phase 3b — unified build/test entrypoint.** Adds a root `Makefile` as the single source for the install/lint/typecheck/test/build recipe across all four components, and repoints the README and CONTRIBUTING guides at it — resolving the "build/test recipe disagrees across multiple sources" finding (the docs had drifted between `npm`/`pnpm` and bare `pytest`/`uv run pytest`). Part of the `0.5.0` cycle on `release/0.5.x`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Build/infrastructure changes

## Related Issues

No tracking issue — roadmap-driven (`notes/architecture-review.md`, Phase 3).

## Changes Made

- New root `Makefile` (Node via pnpm, Python via uv) with `install`, `lint`, `typecheck`, `test`, `build`, the per-suite `lint-*`/`test-*` targets, and `dev-infra`/`stop`. `make help` lists them. The recipes mirror what CI runs.
- README "Running tests" and CONTRIBUTING setup/pre-PR sections now point at `make` instead of their previous per-package `npm`/`pytest` instructions.
- Gitignored `wikibase/uv.lock` (an accidental `uv run` artifact; wikibase installs via pip in CI).

## Testing

### Test Environment

- OS: macOS (Darwin 24.6.0)

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. `make help` lists every target.
2. `make lint-wikibase` runs (ruff check + format). The recipes match the per-suite commands CI already uses, so `make lint` / `make test` reproduce CI locally.

## Screenshots/Videos

N/A.

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [x] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

## Breaking Changes

**Breaking changes:**
- None.

**Migration guide:**
- N/A. Contributors can use `make test` / `make lint` instead of the old per-package commands.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The `.github/workflows/README.md` correction (it claims e2e/model-service gate, GPU docker builds, and multi-arch that the workflows don't actually do) and the `test-e2e`/`test-model-service` CI-gate reconciliation are a separate follow-up (Phase 3c), to keep this PR focused on the test-recipe single source.

## Reviewer Guidance

The `Makefile` is the substance; confirm the recipes match what you run today (they mirror `ci.yml`). The README/CONTRIBUTING edits just replace the divergent per-package blocks with `make` targets.
