### PR TITLE
refactor: extract personas into a service/repository layer (Phase 4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 - Rewrote `.github/workflows/README.md` to match what the workflows actually do; it had claimed an in-CI e2e gate, a GPU docker-image matrix, and multi-arch release images, none of which happen. Removed the permanently-disabled (`if: false`) `test-e2e` job from `ci.yml` (end-to-end tests run in the dedicated `e2e-mock.yml` / `e2e-real-models.yml` workflows). The `test-model-service` job is now listed in the quality gate as **advisory** (its result is reported but does not block, since its full ML-stack install is disk-sensitive on shared runners), replacing the summary's inaccurate "skipped (disk space constraints)". Corrected `DOCKER_QUICK_REFERENCE.md` to reference `SESSION_SECRET` (the variable the stack uses) instead of the non-existent `COOKIE_SECRET`.
 
+#### Backend Modularization: Service/Repository Layer
+
+- Extracted the **personas** domain into a `PersonaRepository` (pure Prisma data access) and a `PersonaService` (orchestration, RBAC, and response mapping), reducing `server/src/routes/personas.ts` from 1641 lines with 44 direct `prisma.*` calls to 640 thin lines with zero. Routes now validate input and dispatch to the service; the service owns the CASL ability checks, the list-mode branching, the `isSystemGenerated` coercion, and the ontology type-deletion / world-state-cleanup orchestration; the repository owns every query. RBAC decisions, response shapes, and behavior are unchanged (the full personas route-test suite and the local E2E suite pass). This establishes the pattern for the remaining domain extractions.
+- The persona API response and the frontend `Persona` type now expose `projectId`, which had been silently stripped by the response schema, enabling project-scoped persona browsing.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases

--- a/annotation-tool/src/models/user.ts
+++ b/annotation-tool/src/models/user.ts
@@ -39,6 +39,8 @@ export interface Persona {
   details: string
   /** ID of the user who owns this persona (optional) */
   userId?: string
+  /** ID of the project this persona is scoped to, or null for the personal workspace */
+  projectId?: string | null
   /** Whether this persona was system-generated (e.g., Automated persona) */
   isSystemGenerated?: boolean
   /** Whether this persona should be hidden from the UI */

--- a/annotation-tool/test/e2e/fixtures/test-context.ts
+++ b/annotation-tool/test/e2e/fixtures/test-context.ts
@@ -451,11 +451,17 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
    * worker's lifecycle (the test does NOT delete on teardown so
    * persisted-annotation data survives the reload assertion).
    */
-  // Name includes workerIndex + first 8 chars of testUser.id so admin
-  // sessions see globally-unique options even when previous test runs
-  // left orphans in the database.
+  // Name includes workerIndex + first 8 chars of testUser.id AND the per-test
+  // id so each option is globally unique. Without the per-test id, two tests
+  // on the same worker created two personas with the SAME name (workerIndex
+  // and userId are both worker-stable and the fixture does not delete on
+  // teardown), so the persona dropdown resolved to N same-named options and
+  // failed the strict-mode locator. A retry of the same test reuses its persona
+  // via findPersonaByName below (the testId is stable across retries). Worker
+  // cleanup deletes by userId, so the longer name does not affect teardown.
   testPersonaPersistent: async ({ db, testUser, workerSessionToken }, use, testInfo) => {
-    const personaName = `Test Analyst (Persistent W${testInfo.workerIndex}-${testUser.id.slice(0, 8)})`
+    const perTestId = testInfo.testId.replace(/[^a-zA-Z0-9]/g, '').slice(-12)
+    const personaName = `Test Analyst (Persistent W${testInfo.workerIndex}-${testUser.id.slice(0, 8)}-${perTestId})`
     const existing = await db.findPersonaByName(testUser.id, personaName, workerSessionToken)
     const persona = existing ?? await db.createPersona({
       userId: testUser.id,

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -58,6 +58,11 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 - Rewrote `.github/workflows/README.md` to match what the workflows actually do; it had claimed an in-CI e2e gate, a GPU docker-image matrix, and multi-arch release images, none of which happen. Removed the permanently-disabled (`if: false`) `test-e2e` job from `ci.yml` (end-to-end tests run in the dedicated `e2e-mock.yml` / `e2e-real-models.yml` workflows). The `test-model-service` job is now listed in the quality gate as **advisory** (its result is reported but does not block, since its full ML-stack install is disk-sensitive on shared runners), replacing the summary's inaccurate "skipped (disk space constraints)". Corrected `DOCKER_QUICK_REFERENCE.md` to reference `SESSION_SECRET` (the variable the stack uses) instead of the non-existent `COOKIE_SECRET`.
 
+#### Backend Modularization: Service/Repository Layer
+
+- Extracted the **personas** domain into a `PersonaRepository` (pure Prisma data access) and a `PersonaService` (orchestration, RBAC, and response mapping), reducing `server/src/routes/personas.ts` from 1641 lines with 44 direct `prisma.*` calls to 640 thin lines with zero. Routes now validate input and dispatch to the service; the service owns the CASL ability checks, the list-mode branching, the `isSystemGenerated` coercion, and the ontology type-deletion / world-state-cleanup orchestration; the repository owns every query. RBAC decisions, response shapes, and behavior are unchanged (the full personas route-test suite and the local E2E suite pass). This establishes the pattern for the remaining domain extractions.
+- The persona API response and the frontend `Persona` type now expose `projectId`, which had been silently stripped by the response schema, enabling project-scoped persona browsing.
+
 ### Fixed
 
 #### Release Workflow Now Publishes GitHub Releases

--- a/server/src/repositories/PersonaRepository.ts
+++ b/server/src/repositories/PersonaRepository.ts
@@ -1,0 +1,193 @@
+import { PrismaClient, Persona, Ontology, Prisma } from '@prisma/client'
+
+/**
+ * Persona row joined with its ontology.
+ *
+ * Used by read paths that need the ontology in the same round-trip
+ * (deletion preview, ontology endpoints, and the type-deletion flows).
+ */
+export type PersonaWithOntology = Prisma.PersonaGetPayload<{
+  include: { ontology: true }
+}>
+
+/**
+ * Repository for all Persona and Ontology database access.
+ *
+ * This class owns every Prisma call in the personas domain. It performs no
+ * authorization: callers (the PersonaService) decide who may invoke a method.
+ * Methods return raw Prisma model types and propagate Prisma errors (for
+ * example P2025 on a missing update target) to their callers.
+ *
+ * @example
+ * ```typescript
+ * const repo = new PersonaRepository(fastify.prisma)
+ * const persona = await repo.findById(id)
+ * if (!persona) {
+ *   throw new NotFoundError('Persona', id)
+ * }
+ * ```
+ */
+export class PersonaRepository {
+  /**
+   * Creates a new PersonaRepository instance.
+   *
+   * @param prisma - Prisma client instance for database access
+   */
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Finds personas matching a WHERE clause, newest first.
+   *
+   * Used by the list endpoint; the caller supplies the mode-specific filter
+   * (single-user, unauthenticated, demo, or CASL-scoped authenticated).
+   *
+   * @param where - Prisma WHERE clause selecting the visible personas
+   * @returns matching personas ordered by creation date descending
+   */
+  async findManyForList(where: Prisma.PersonaWhereInput): Promise<Persona[]> {
+    return this.prisma.persona.findMany({
+      where,
+      orderBy: { createdAt: 'desc' }
+    })
+  }
+
+  /**
+   * Finds a persona by ID.
+   *
+   * @param id - Persona UUID
+   * @returns the persona, or null if not found
+   */
+  async findById(id: string): Promise<Persona | null> {
+    return this.prisma.persona.findUnique({ where: { id } })
+  }
+
+  /**
+   * Finds a persona by ID with its ontology included.
+   *
+   * @param id - Persona UUID
+   * @returns the persona with its ontology, or null if not found
+   */
+  async findByIdWithOntology(id: string): Promise<PersonaWithOntology | null> {
+    return this.prisma.persona.findUnique({
+      where: { id },
+      include: { ontology: true }
+    })
+  }
+
+  /**
+   * Finds many personas by ID with their ontologies included.
+   *
+   * Used by the batch ontology endpoint. Personas without an ontology are
+   * still returned; the caller filters them out.
+   *
+   * @param ids - Persona UUIDs to fetch
+   * @returns matching personas, each with its ontology
+   */
+  async findManyWithOntology(ids: string[]): Promise<PersonaWithOntology[]> {
+    return this.prisma.persona.findMany({
+      where: { id: { in: ids } },
+      include: { ontology: true }
+    })
+  }
+
+  /**
+   * Creates a persona together with an empty ontology in a single call.
+   *
+   * @param data - Prisma create input (must nest an ontology create)
+   * @returns the created persona
+   */
+  async createWithOntology(data: Prisma.PersonaCreateInput): Promise<Persona> {
+    return this.prisma.persona.create({ data })
+  }
+
+  /**
+   * Updates a persona.
+   *
+   * @param id - Persona UUID
+   * @param data - Prisma update input
+   * @returns the updated persona
+   * @throws {Prisma.PrismaClientKnownRequestError} P2025 if the persona does not exist
+   */
+  async update(id: string, data: Prisma.PersonaUpdateInput): Promise<Persona> {
+    return this.prisma.persona.update({ where: { id }, data })
+  }
+
+  /**
+   * Deletes a persona (cascades to its ontology, summaries, and annotations).
+   *
+   * @param id - Persona UUID
+   * @returns the deleted persona
+   * @throws {Prisma.PrismaClientKnownRequestError} P2025 if the persona does not exist
+   */
+  async delete(id: string): Promise<Persona> {
+    return this.prisma.persona.delete({ where: { id } })
+  }
+
+  /**
+   * Updates a persona's ontology, keyed by personaId.
+   *
+   * @param personaId - Persona UUID owning the ontology
+   * @param data - Prisma ontology update input
+   * @returns the updated ontology
+   */
+  async updateOntology(personaId: string, data: Prisma.OntologyUpdateInput): Promise<Ontology> {
+    return this.prisma.ontology.update({
+      where: { personaId },
+      data
+    })
+  }
+
+  /**
+   * Counts annotations matching a WHERE clause.
+   *
+   * @param where - Prisma annotation WHERE clause
+   * @returns number of matching annotations
+   */
+  async countAnnotations(where: Prisma.AnnotationWhereInput): Promise<number> {
+    return this.prisma.annotation.count({ where })
+  }
+
+  /**
+   * Counts video summaries for a persona.
+   *
+   * @param personaId - Persona UUID
+   * @returns number of summaries for the persona
+   */
+  async countVideoSummaries(personaId: string): Promise<number> {
+    return this.prisma.videoSummary.count({ where: { personaId } })
+  }
+
+  /**
+   * Deletes annotations matching a WHERE clause.
+   *
+   * @param where - Prisma annotation WHERE clause
+   * @returns Prisma batch payload with the deleted count
+   */
+  async deleteAnnotations(where: Prisma.AnnotationWhereInput): Promise<Prisma.BatchPayload> {
+    return this.prisma.annotation.deleteMany({ where })
+  }
+
+  /**
+   * Finds a user's personal world state (the row scoped to the user with no
+   * project). This is the world state the persona-deletion and type-deletion
+   * cleanup paths mutate.
+   *
+   * @param userId - owning user ID
+   * @returns the personal world state, or null if the user has none
+   */
+  async findPersonalWorldState(userId: string) {
+    return this.prisma.worldState.findFirst({
+      where: { userId, projectId: null }
+    })
+  }
+
+  /**
+   * Updates a world state row by ID.
+   *
+   * @param id - World state ID
+   * @param data - Prisma world state update input
+   */
+  async updateWorldState(id: string, data: Prisma.WorldStateUpdateInput): Promise<void> {
+    await this.prisma.worldState.update({ where: { id }, data })
+  }
+}

--- a/server/src/routes/personas.ts
+++ b/server/src/routes/personas.ts
@@ -1,48 +1,18 @@
 import { Type } from '@sinclair/typebox'
-import { FastifyPluginAsync } from 'fastify'
+import { FastifyPluginAsync, FastifyRequest } from 'fastify'
 import { z } from 'zod'
-import { Prisma } from '@prisma/client'
-import { accessibleBy } from '@casl/prisma'
-import { subject } from '@casl/ability'
 import { requireAuth, optionalAuth } from '@middleware/auth.js'
 import { buildAbilities } from '../middleware/abilities.js'
-import { NotFoundError, ForbiddenError } from '@lib/errors.js'
-import { isDemoModeEnabled } from '../lib/demo-flags.js'
-import { isSingleUserMode } from '@services/user-service.js'
 import { personaOperationCounter } from '../metrics.js'
-import {
-  updateGlossesInTypes,
-  countTypeRefsInGlosses,
-  removeTypeAssignmentsFromEntities,
-  removeEventInterpretationsFromEvents,
-  countTypeAssignments,
-  countEventInterpretations,
-} from '@lib/reference-cleanup.js'
-import {
-  asTypesWithGloss,
-  asEntities,
-  asEvents,
-} from '@lib/prisma-json.js'
+import { PersonaRepository } from '../repositories/PersonaRepository.js'
+import { PersonaService } from '../services/persona-service.js'
 
 /**
- * Converts a typed array to Prisma.InputJsonValue for storage in JSON columns.
- * Prisma JSON columns accept any serializable value at runtime; this function
- * bridges the TypeScript gap without an unsafe cast.
+ * Nullable-string helper for response schemas. Using Type.Unsafe with the
+ * array type form keeps null values from being coerced to "" by
+ * fast-json-stringify.
  */
-function toJson(value: unknown): Prisma.InputJsonValue {
-  return value as Prisma.InputJsonValue
-}
-
-/**
- * Request body for ontology update endpoint.
- */
-interface OntologyUpdateBody {
-  entities?: unknown[];
-  roles?: unknown[];
-  events?: unknown[];
-  relationTypes?: unknown[];
-  relations?: unknown[];
-}
+const NullableString = Type.Unsafe<string | null>({ type: ['string', 'null'] })
 
 /**
  * TypeBox schema for Persona response.
@@ -53,11 +23,25 @@ const PersonaSchema = Type.Object({
   name: Type.String({ minLength: 1 }),
   role: Type.String(),
   informationNeed: Type.String(),
-  details: Type.Union([Type.String(), Type.Null()]),
+  details: NullableString,
+  projectId: Type.Union([Type.String({ format: 'uuid' }), Type.Null()]),
   isSystemGenerated: Type.Boolean(),
   hidden: Type.Boolean(),
   createdAt: Type.String({ format: 'date-time' }),
   updatedAt: Type.String({ format: 'date-time' })
+})
+
+/** TypeBox schema for the API ontology response shape. */
+const OntologyResponseSchema = Type.Object({
+  id: Type.String(),
+  personaId: Type.String(),
+  entities: Type.Array(Type.Any()),
+  roles: Type.Array(Type.Any()),
+  events: Type.Array(Type.Any()),
+  relationTypes: Type.Array(Type.Any()),
+  relations: Type.Array(Type.Any()),
+  createdAt: Type.String(),
+  updatedAt: Type.String()
 })
 
 /**
@@ -89,24 +73,43 @@ const updatePersonaSchema = z.object({
 
 /**
  * Fastify plugin for persona-related routes.
- * Provides CRUD operations for personas using Prisma ORM.
+ *
+ * Routes perform HTTP concerns only: schema validation, request parsing, and
+ * dispatch to a per-request PersonaService that owns business rules and RBAC.
+ * The PersonaRepository owns all Prisma access.
  *
  * Routes:
- * - GET /api/personas - List all personas
- * - POST /api/personas - Create a new persona
- * - GET /api/personas/:id - Get a specific persona
+ * - GET /api/personas - List personas
+ * - POST /api/personas - Create a persona with an empty ontology
+ * - GET /api/personas/:id - Get a persona
  * - PUT /api/personas/:id - Update a persona
+ * - GET /api/personas/:id/deletion-preview - Preview a persona deletion
  * - DELETE /api/personas/:id - Delete a persona
+ * - GET /api/personas/:id/ontology - Get a persona's ontology
+ * - POST /api/personas/ontologies - Batch-fetch ontologies
+ * - PUT /api/personas/:id/ontology - Update a persona's ontology
+ * - GET/DELETE the entity/role/event/relation-type endpoints with cleanup
  */
 const personasRoute: FastifyPluginAsync = async (fastify) => {
+  // Request-independent: one repository for the plugin's lifetime.
+  const repository = new PersonaRepository(fastify.prisma)
+
   /**
-   * List all personas.
-   * In single-user mode, returns all personas.
-   * In multi-user mode with authentication, returns current user's personas only.
-   * Without authentication, returns public/system personas.
+   * Builds a per-request service from the request-scoped CASL ability and the
+   * authenticated user's id and system role.
+   */
+  const serviceFor = (request: FastifyRequest): PersonaService =>
+    new PersonaService(
+      repository,
+      request.ability ?? null,
+      request.user?.id,
+      request.user?.systemRole ?? undefined
+    )
+
+  /**
+   * List personas visible to the caller.
    *
    * @route GET /api/personas
-   * @returns Array of personas
    */
   fastify.get('/api/personas', {
     onRequest: [optionalAuth, buildAbilities],
@@ -118,82 +121,15 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    if (isSingleUserMode()) {
-      // Single-user mode: return all non-hidden personas
-      const personas = await fastify.prisma.persona.findMany({
-        where: { hidden: false },
-        orderBy: { createdAt: 'desc' }
-      })
-      return reply.send(personas)
-    }
-
-    if (!request.user || !request.ability) {
-      // Unauthenticated: return only non-hidden system personas
-      const personas = await fastify.prisma.persona.findMany({
-        where: { isSystemGenerated: true, hidden: false },
-        orderBy: { createdAt: 'desc' }
-      })
-      return reply.send(personas)
-    }
-
-    // FOVEA_DEMO_MODE override: the booth flow that ships on
-    // demo.fovea.video auto-issues demo-anonymous-* sessions
-    // (server/src/demo/anonymous-session.ts) so the visitor is
-    // technically authenticated and the unauthenticated branch above
-    // does not fire — but the auto-issued anon user has no CASL
-    // grants of their own, so the per-user accessibleBy filter below
-    // returns the empty set and the persona dropdown reads "No
-    // personas found". The Persona Builder workspace and every tour
-    // that drives a persona-rooted ontology (ontology-authoring,
-    // wikidata-augmentation, world-layer, etc.) then has no anchor
-    // to mount against because the workspace's tab list is gated on
-    // persona selection. Inside FOVEA_DEMO_MODE we explicitly widen
-    // the read scope to every non-hidden system-generated persona —
-    // the seeded "Automated" persona plus any future
-    // isSystemGenerated=true rows an admin promotes — so the tours
-    // run end-to-end against the same seeded ontology a self-hosted
-    // single-user deployment shows. This is gated on FOVEA_DEMO_MODE
-    // so production multi-user deployments keep their per-user RBAC
-    // intact.
-    if (isDemoModeEnabled()) {
-      // The seeded Automated persona ships with hidden=true so it
-      // does not clutter a multi-user deployment's persona dropdown
-      // for end users who do not need it. The tour flow that walks
-      // visitors through the persona-rooted workspaces needs it
-      // visible, so the override drops the hidden filter — the
-      // visible result is every isSystemGenerated persona regardless
-      // of the hidden flag. Production deployments without
-      // FOVEA_DEMO_MODE keep their per-user RBAC + the hidden filter
-      // exactly as before.
-      const personas = await fastify.prisma.persona.findMany({
-        where: { isSystemGenerated: true },
-        orderBy: { createdAt: 'desc' }
-      })
-      return reply.send(personas)
-    }
-
-    // Authenticated: filter by CASL abilities
-    const personas = await fastify.prisma.persona.findMany({
-      where: {
-        AND: [
-          { hidden: false },
-          accessibleBy(request.ability, 'read').Persona,
-        ],
-      },
-      orderBy: { createdAt: 'desc' }
-    })
+    const service = serviceFor(request)
+    const personas = await service.list()
     return reply.send(personas)
   })
 
   /**
-   * Create a new persona.
-   * Creates a persona and its associated ontology in the database.
-   * In single-user mode, uses default user if not authenticated.
-   * In multi-user mode, requires authentication.
+   * Create a persona and its empty ontology in one call.
    *
    * @route POST /api/personas
-   * @param request.body - Persona data
-   * @returns Created persona
    */
   fastify.post('/api/personas', {
     onRequest: [requireAuth, buildAbilities],
@@ -216,63 +152,17 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     }
   }, async (request, reply) => {
-    if (!request.ability) throw new ForbiddenError('No abilities defined')
-    const userId = request.user!.id
-
     const validatedData = createPersonaSchema.parse(request.body)
-    const projectId = validatedData.projectId || null
-
-    // Pre-authorize: verify the caller can create a Persona in this scope
-    const candidate = subject('Persona', {
-      userId,
-      projectId,
-    })
-    if (!request.ability.can('create', candidate)) {
-      throw new ForbiddenError('Cannot create Persona in this scope')
-    }
-
-    // Only system_admin may flag a persona as system-generated, since
-    // system personas are visible to unauthenticated visitors via the
-    // unauthenticated GET /api/personas branch. A non-admin attempting
-    // to set this flag has it silently coerced to false rather than 403
-    // so legitimate clients that send the field unconditionally still
-    // succeed.
-    const isSystemGenerated = request.user?.systemRole === 'system_admin'
-      ? validatedData.isSystemGenerated
-      : false
-
-    const persona = await fastify.prisma.persona.create({
-      data: {
-        name: validatedData.name,
-        role: validatedData.role,
-        informationNeed: validatedData.informationNeed,
-        details: validatedData.details || null,
-        isSystemGenerated,
-        hidden: validatedData.hidden,
-        userId,
-        projectId,
-        ontology: {
-          create: {
-            entityTypes: [],
-            eventTypes: [],
-            roleTypes: [],
-            relationTypes: []
-          }
-        }
-      }
-    })
-
+    const service = serviceFor(request)
+    const persona = await service.create(validatedData)
     personaOperationCounter.add(1, { operation: 'create', status: 'success' })
     return reply.code(201).send(persona)
   })
 
   /**
-   * Get a specific persona by ID.
-   * In multi-user mode, verifies user owns the persona or it's a system persona.
+   * Get a persona by ID.
    *
    * @route GET /api/personas/:id
-   * @param request.params.id - Persona UUID
-   * @returns Persona object
    */
   fastify.get<{ Params: { id: string } }>('/api/personas/:id', {
     onRequest: [optionalAuth, buildAbilities],
@@ -284,50 +174,20 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }),
       response: {
         200: PersonaSchema,
-        403: Type.Object({
-          error: Type.String()
-        }),
-        404: Type.Object({
-          error: Type.String()
-        })
+        403: Type.Object({ error: Type.String() }),
+        404: Type.Object({ error: Type.String() })
       }
     }
   }, async (request, reply) => {
-    const { id } = request.params
-
-    const persona = await fastify.prisma.persona.findUnique({
-      where: { id }
-    })
-
-    if (!persona) {
-      throw new NotFoundError('Persona', id)
-    }
-
-    // Unauthenticated callers can only see public system personas
-    if (!request.user || !request.ability) {
-      if (!persona.isSystemGenerated || persona.hidden) {
-        throw new NotFoundError('Persona', id)
-      }
-      return reply.send(persona)
-    }
-
-    // Authenticated: CASL instance-level check
-    if (!request.ability.can('read', subject('Persona', persona))) {
-      throw new ForbiddenError('Access denied')
-    }
-
+    const service = serviceFor(request)
+    const persona = await service.getById(request.params.id)
     return reply.send(persona)
   })
 
   /**
    * Update a persona.
-   * Performs partial update of persona fields.
-   * Requires authentication and ownership verification.
    *
    * @route PUT /api/personas/:id
-   * @param request.params.id - Persona UUID
-   * @param request.body - Fields to update
-   * @returns Updated persona
    */
   fastify.put<{ Params: { id: string } }>('/api/personas/:id', {
     onRequest: [requireAuth, buildAbilities],
@@ -347,62 +207,22 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }),
       response: {
         200: PersonaSchema,
-        403: Type.Object({
-          error: Type.String()
-        }),
-        404: Type.Object({
-          error: Type.String()
-        })
+        403: Type.Object({ error: Type.String() }),
+        404: Type.Object({ error: Type.String() })
       }
     }
   }, async (request, reply) => {
-    const { id } = request.params
-    if (!request.ability) throw new ForbiddenError('No abilities defined')
     const validatedData = updatePersonaSchema.parse(request.body)
-
-    const existingPersona = await fastify.prisma.persona.findUnique({
-      where: { id }
-    })
-
-    if (!existingPersona) {
-      throw new NotFoundError('Persona', id)
-    }
-
-    if (!request.ability.can('update', subject('Persona', existingPersona))) {
-      throw new ForbiddenError('Cannot update this Persona')
-    }
-
-    // Only system_admin may toggle isSystemGenerated; strip it from
-    // non-admin updates so a regular user cannot publish their persona to
-    // anonymous visitors via the unauthenticated GET /api/personas branch.
-    const updatePayload = { ...validatedData }
-    if (request.user?.systemRole !== 'system_admin') {
-      delete (updatePayload as { isSystemGenerated?: boolean }).isSystemGenerated
-    }
-
-    try {
-      const persona = await fastify.prisma.persona.update({
-        where: { id },
-        data: updatePayload
-      })
-      personaOperationCounter.add(1, { operation: 'update', status: 'success' })
-      return reply.send(persona)
-    } catch (error: unknown) {
-      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
-        throw new NotFoundError('Persona', id)
-      }
-      throw error
-    }
+    const service = serviceFor(request)
+    const persona = await service.update(request.params.id, validatedData)
+    personaOperationCounter.add(1, { operation: 'update', status: 'success' })
+    return reply.send(persona)
   })
 
   /**
-   * Get deletion preview for a persona.
-   * Returns counts of items that will be affected when the persona is deleted.
-   * Used to show a warning to the user before deletion.
+   * Get a deletion preview for a persona.
    *
    * @route GET /api/personas/:id/deletion-preview
-   * @param request.params.id - Persona UUID
-   * @returns Counts of affected items
    */
   fastify.get<{ Params: { id: string } }>('/api/personas/:id/deletion-preview', {
     onRequest: [requireAuth, buildAbilities],
@@ -419,97 +239,20 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
           summaryCount: Type.Number(),
           worldAssignmentCount: Type.Number()
         }),
-        403: Type.Object({
-          error: Type.String()
-        }),
-        404: Type.Object({
-          error: Type.String()
-        })
+        403: Type.Object({ error: Type.String() }),
+        404: Type.Object({ error: Type.String() })
       }
     }
   }, async (request, reply) => {
-    const { id } = request.params
-    if (!request.ability) throw new ForbiddenError('No abilities defined')
-
-    const persona = await fastify.prisma.persona.findUnique({
-      where: { id },
-      include: { ontology: true }
-    })
-
-    if (!persona) {
-      throw new NotFoundError('Persona', id)
-    }
-
-    if (!request.ability.can('delete', subject('Persona', persona))) {
-      throw new ForbiddenError('Cannot access this Persona')
-    }
-
-    // Count types in ontology
-    const entityTypes = Array.isArray(persona.ontology?.entityTypes) ? persona.ontology.entityTypes : []
-    const roleTypes = Array.isArray(persona.ontology?.roleTypes) ? persona.ontology.roleTypes : []
-    const eventTypes = Array.isArray(persona.ontology?.eventTypes) ? persona.ontology.eventTypes : []
-    const relationTypes = Array.isArray(persona.ontology?.relationTypes) ? persona.ontology.relationTypes : []
-    const typeCount = entityTypes.length + roleTypes.length + eventTypes.length + relationTypes.length
-
-    // Count annotations with this personaId
-    const annotationCount = await fastify.prisma.annotation.count({
-      where: { personaId: id }
-    })
-
-    // Count video summaries for this persona
-    const summaryCount = await fastify.prisma.videoSummary.count({
-      where: { personaId: id }
-    })
-
-    // Count world state assignments for this persona
-    let worldAssignmentCount = 0
-    const worldState = await fastify.prisma.worldState.findFirst({
-      where: { userId: persona.userId, projectId: null }
-    })
-
-    if (worldState) {
-      // Count Entity.typeAssignments with this personaId
-      const entities = (worldState.entities as Array<{ typeAssignments?: Array<{ personaId: string }> }>) || []
-      for (const entity of entities) {
-        worldAssignmentCount += (entity.typeAssignments || []).filter(a => a.personaId === id).length
-      }
-
-      // Count Event.personaInterpretations with this personaId
-      const events = (worldState.events as Array<{ personaInterpretations?: Array<{ personaId: string }> }>) || []
-      for (const event of events) {
-        worldAssignmentCount += (event.personaInterpretations || []).filter(i => i.personaId === id).length
-      }
-
-      // Count EntityCollection.typeAssignments with this personaId
-      const entityCollections = (worldState.entityCollections as Array<{ typeAssignments?: Array<{ personaId: string }> }>) || []
-      for (const collection of entityCollections) {
-        worldAssignmentCount += (collection.typeAssignments || []).filter(a => a.personaId === id).length
-      }
-
-      // Count EventCollection.typeAssignments with this personaId
-      const eventCollections = (worldState.eventCollections as Array<{ typeAssignments?: Array<{ personaId: string }> }>) || []
-      for (const collection of eventCollections) {
-        worldAssignmentCount += (collection.typeAssignments || []).filter(a => a.personaId === id).length
-      }
-    }
-
-    return reply.send({
-      typeCount,
-      annotationCount,
-      summaryCount,
-      worldAssignmentCount
-    })
+    const service = serviceFor(request)
+    const preview = await service.getDeletionPreview(request.params.id)
+    return reply.send(preview)
   })
 
   /**
-   * Delete a persona.
-   * Deletes the persona and its associated ontology (cascade).
-   * Also cleans up orphaned type assignments in world state.
-   * Requires authentication and ownership verification.
+   * Delete a persona and clean its world-state references.
    *
    * @route DELETE /api/personas/:id
-   * @param request.params.id - Persona UUID
-   * @returns Success message
    */
   fastify.delete<{ Params: { id: string } }>('/api/personas/:id', {
     onRequest: [requireAuth, buildAbilities],
@@ -520,109 +263,22 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
         id: Type.String({ format: 'uuid' })
       }),
       response: {
-        200: Type.Object({
-          message: Type.String()
-        }),
-        403: Type.Object({
-          error: Type.String()
-        }),
-        404: Type.Object({
-          error: Type.String()
-        })
+        200: Type.Object({ message: Type.String() }),
+        403: Type.Object({ error: Type.String() }),
+        404: Type.Object({ error: Type.String() })
       }
     }
   }, async (request, reply) => {
-    const { id } = request.params
-    if (!request.ability) throw new ForbiddenError('No abilities defined')
-
-    const existingPersona = await fastify.prisma.persona.findUnique({
-      where: { id }
-    })
-
-    if (!existingPersona) {
-      throw new NotFoundError('Persona', id)
-    }
-
-    if (!request.ability.can('delete', subject('Persona', existingPersona))) {
-      throw new ForbiddenError('Cannot delete this Persona')
-    }
-
-    // Clean up world state: remove type assignments and interpretations for this persona
-    const worldState = await fastify.prisma.worldState.findFirst({
-      where: { userId: existingPersona.userId, projectId: null }
-    })
-
-    if (worldState) {
-      // Helper type definitions for world state items
-      interface EntityWithAssignments {
-        typeAssignments?: Array<{ personaId: string; [key: string]: unknown }>
-        [key: string]: unknown
-      }
-      interface EventWithInterpretations {
-        personaInterpretations?: Array<{ personaId: string; [key: string]: unknown }>
-        [key: string]: unknown
-      }
-      interface CollectionWithAssignments {
-        typeAssignments?: Array<{ personaId: string; [key: string]: unknown }>
-        [key: string]: unknown
-      }
-
-      // Clean Entity.typeAssignments
-      const entities = (worldState.entities as EntityWithAssignments[]) || []
-      const cleanedEntities = entities.map(entity => ({
-        ...entity,
-        typeAssignments: (entity.typeAssignments || []).filter(a => a.personaId !== id)
-      }))
-
-      // Clean Event.personaInterpretations
-      const events = (worldState.events as EventWithInterpretations[]) || []
-      const cleanedEvents = events.map(event => ({
-        ...event,
-        personaInterpretations: (event.personaInterpretations || []).filter(i => i.personaId !== id)
-      }))
-
-      // Clean EntityCollection.typeAssignments
-      const entityCollections = (worldState.entityCollections as CollectionWithAssignments[]) || []
-      const cleanedEntityCollections = entityCollections.map(collection => ({
-        ...collection,
-        typeAssignments: (collection.typeAssignments || []).filter(a => a.personaId !== id)
-      }))
-
-      // Clean EventCollection.typeAssignments
-      const eventCollections = (worldState.eventCollections as CollectionWithAssignments[]) || []
-      const cleanedEventCollections = eventCollections.map(collection => ({
-        ...collection,
-        typeAssignments: (collection.typeAssignments || []).filter(a => a.personaId !== id)
-      }))
-
-      // Update world state with cleaned data
-      await fastify.prisma.worldState.update({
-        where: { id: worldState.id },
-        data: {
-          entities: toJson(cleanedEntities),
-          events: toJson(cleanedEvents),
-          entityCollections: toJson(cleanedEntityCollections),
-          eventCollections: toJson(cleanedEventCollections)
-        }
-      })
-    }
-
-    try {
-      await fastify.prisma.persona.delete({
-        where: { id }
-      })
-      personaOperationCounter.add(1, { operation: 'delete', status: 'success' })
-      return reply.send({ message: 'Persona deleted successfully' })
-    } catch (error: unknown) {
-      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
-        throw new NotFoundError('Persona', id)
-      }
-      throw error
-    }
+    const service = serviceFor(request)
+    await service.delete(request.params.id)
+    personaOperationCounter.add(1, { operation: 'delete', status: 'success' })
+    return reply.send({ message: 'Persona deleted successfully' })
   })
 
   /**
-   * Get ontology for a specific persona.
+   * Get a persona's ontology.
+   *
+   * @route GET /api/personas/:id/ontology
    */
   fastify.get<{ Params: { id: string } }>('/api/personas/:id/ontology', {
     onRequest: [optionalAuth, buildAbilities],
@@ -633,75 +289,20 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
         id: Type.String({ format: 'uuid' })
       }),
       response: {
-        200: Type.Object({
-          id: Type.String(),
-          personaId: Type.String(),
-          entities: Type.Array(Type.Any()),
-          roles: Type.Array(Type.Any()),
-          events: Type.Array(Type.Any()),
-          relationTypes: Type.Array(Type.Any()),
-          relations: Type.Array(Type.Any()),
-          createdAt: Type.String(),
-          updatedAt: Type.String()
-        }),
+        200: OntologyResponseSchema,
         404: Type.Object({ error: Type.String() })
       }
     }
   }, async (request, reply) => {
-    const { id } = request.params
-
-    const persona = await fastify.prisma.persona.findUnique({
-      where: { id },
-      include: { ontology: true }
-    })
-
-    if (!persona || !persona.ontology) {
-      throw new NotFoundError('Persona or ontology', id)
-    }
-
-    // Unauthenticated: only system personas are visible
-    if (!request.user || !request.ability) {
-      if (!persona.isSystemGenerated || persona.hidden) {
-        throw new NotFoundError('Persona or ontology', id)
-      }
-    } else if (!request.ability.can('read', subject('Persona', persona))) {
-      // FOVEA_DEMO_MODE override: in demo mode every system-
-      // generated persona is part of the deployment's public
-      // tour catalogue and must be readable by any caller whose
-      // CASL ability is scoped to their own data (anonymous demo
-      // sessions, non-admin users opening a tour). Without this
-      // widening the VideoBrowser cannot fetch the seeded
-      // persona's ontology and every video card renders blank.
-      if (!isDemoModeEnabled() || !persona.isSystemGenerated) {
-        throw new ForbiddenError('Access denied')
-      }
-    }
-
-    // Map database field names to API field names
-    return reply.send({
-      id: persona.ontology.id,
-      personaId: persona.ontology.personaId,
-      entities: persona.ontology.entityTypes || [],
-      roles: persona.ontology.roleTypes || [],
-      events: persona.ontology.eventTypes || [],
-      relationTypes: persona.ontology.relationTypes || [],
-      relations: [],
-      createdAt: persona.ontology.createdAt.toISOString(),
-      updatedAt: persona.ontology.updatedAt.toISOString()
-    })
+    const service = serviceFor(request)
+    const ontology = await service.getOntology(request.params.id)
+    return reply.send(ontology)
   })
 
   /**
    * Batch-fetch ontologies for many personas in one round-trip.
    *
-   * The VideoBrowser needs every visible persona's ontology on initial load.
-   * Fetching them one at a time (GET /api/personas/:id/ontology per persona)
-   * turns a single page load into one request per persona, which on a large
-   * deployment fans out far enough to trip the rate limit. This endpoint
-   * applies the same per-persona read-permission rules as the single GET and
-   * returns only the ontologies the caller may read (personas that are missing,
-   * have no ontology, or are not readable are simply omitted). Each entry
-   * carries its `personaId` so the client can index the result.
+   * @route POST /api/personas/ontologies
    */
   fastify.post<{ Body: { personaIds: string[] } }>('/api/personas/ontologies', {
     onRequest: [optionalAuth, buildAbilities],
@@ -712,63 +313,27 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
         personaIds: Type.Array(Type.String({ format: 'uuid' }), { maxItems: 100000 })
       }),
       response: {
-        200: Type.Array(Type.Object({
-          id: Type.String(),
-          personaId: Type.String(),
-          entities: Type.Array(Type.Any()),
-          roles: Type.Array(Type.Any()),
-          events: Type.Array(Type.Any()),
-          relationTypes: Type.Array(Type.Any()),
-          relations: Type.Array(Type.Any()),
-          createdAt: Type.String(),
-          updatedAt: Type.String()
-        }))
+        200: Type.Array(OntologyResponseSchema)
       }
     }
   }, async (request, reply) => {
-    const { personaIds } = request.body
-    if (personaIds.length === 0) {
-      return reply.send([])
-    }
-
-    const personas = await fastify.prisma.persona.findMany({
-      where: { id: { in: personaIds } },
-      include: { ontology: true }
-    })
-
-    const ontologies = []
-    for (const persona of personas) {
-      if (!persona.ontology) continue
-
-      // Mirror the read checks from GET /api/personas/:id/ontology exactly.
-      if (!request.user || !request.ability) {
-        // Unauthenticated: only visible system personas.
-        if (!persona.isSystemGenerated || persona.hidden) continue
-      } else if (!request.ability.can('read', subject('Persona', persona))) {
-        // Demo mode widens read to seeded system personas (see single GET).
-        if (!isDemoModeEnabled() || !persona.isSystemGenerated) continue
-      }
-
-      ontologies.push({
-        id: persona.ontology.id,
-        personaId: persona.ontology.personaId,
-        entities: persona.ontology.entityTypes || [],
-        roles: persona.ontology.roleTypes || [],
-        events: persona.ontology.eventTypes || [],
-        relationTypes: persona.ontology.relationTypes || [],
-        relations: [],
-        createdAt: persona.ontology.createdAt.toISOString(),
-        updatedAt: persona.ontology.updatedAt.toISOString()
-      })
-    }
-
+    const service = serviceFor(request)
+    const ontologies = await service.getOntologies(request.body.personaIds)
     return reply.send(ontologies)
   })
 
   /**
-   * Update ontology for a specific persona.
+   * Update a persona's ontology.
+   *
+   * @route PUT /api/personas/:id/ontology
    */
-  fastify.put<{ Params: { id: string }; Body: OntologyUpdateBody }>('/api/personas/:id/ontology', {
+  fastify.put<{ Params: { id: string }; Body: {
+    entities?: unknown[]
+    roles?: unknown[]
+    events?: unknown[]
+    relationTypes?: unknown[]
+    relations?: unknown[]
+  } }>('/api/personas/:id/ontology', {
     onRequest: [requireAuth, buildAbilities],
     schema: {
       description: 'Update ontology for a specific persona',
@@ -784,61 +349,14 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
         relations: Type.Optional(Type.Array(Type.Any()))
       }),
       response: {
-        200: Type.Object({
-          id: Type.String(),
-          personaId: Type.String(),
-          entities: Type.Array(Type.Any()),
-          roles: Type.Array(Type.Any()),
-          events: Type.Array(Type.Any()),
-          relationTypes: Type.Array(Type.Any()),
-          relations: Type.Array(Type.Any()),
-          createdAt: Type.String(),
-          updatedAt: Type.String()
-        }),
+        200: OntologyResponseSchema,
         404: Type.Object({ error: Type.String() })
       }
     }
   }, async (request, reply) => {
-    const { id } = request.params
-    if (!request.ability) throw new ForbiddenError('No abilities defined')
-    const updateData = request.body
-
-    const persona = await fastify.prisma.persona.findUnique({
-      where: { id },
-      include: { ontology: true }
-    })
-
-    if (!persona || !persona.ontology) {
-      throw new NotFoundError('Persona or ontology', id)
-    }
-
-    if (!request.ability.can('update', subject('Persona', persona))) {
-      throw new ForbiddenError('Cannot update this Persona')
-    }
-
-    // Map API field names to database field names
-    const updatedOntology = await fastify.prisma.ontology.update({
-      where: { personaId: id },
-      data: {
-        entityTypes: updateData.entities !== undefined ? (updateData.entities as Prisma.InputJsonValue) : (persona.ontology.entityTypes ?? undefined),
-        roleTypes: updateData.roles !== undefined ? (updateData.roles as Prisma.InputJsonValue) : (persona.ontology.roleTypes ?? undefined),
-        eventTypes: updateData.events !== undefined ? (updateData.events as Prisma.InputJsonValue) : (persona.ontology.eventTypes ?? undefined),
-        relationTypes: updateData.relationTypes !== undefined ? (updateData.relationTypes as Prisma.InputJsonValue) : (persona.ontology.relationTypes ?? undefined)
-      }
-    })
-
-    // Map database field names back to API field names in response
-    return reply.send({
-      id: updatedOntology.id,
-      personaId: updatedOntology.personaId,
-      entities: updatedOntology.entityTypes || [],
-      roles: updatedOntology.roleTypes || [],
-      events: updatedOntology.eventTypes || [],
-      relationTypes: updatedOntology.relationTypes || [],
-      relations: [],
-      createdAt: updatedOntology.createdAt.toISOString(),
-      updatedAt: updatedOntology.updatedAt.toISOString()
-    })
+    const service = serviceFor(request)
+    const ontology = await service.updateOntology(request.params.id, request.body)
+    return reply.send(ontology)
   })
 
   // ==========================================================================
@@ -846,8 +364,7 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
   // ==========================================================================
 
   /**
-   * Get deletion preview for an entity type.
-   * Returns counts of items that will be affected.
+   * Deletion preview for an entity type.
    *
    * @route GET /api/personas/:personaId/ontology/entities/:typeId/deletion-preview
    */
@@ -873,71 +390,14 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('read', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot access this Persona')
-      }
-
-      // Check if type exists
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const targetType = entityTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Entity type', typeId)
-      }
-
-      // Count gloss references across all types
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const eventTypes = asTypesWithGloss(persona.ontology.eventTypes)
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes.filter(t => t.id !== typeId), typeId, personaId, 'entity')
-      glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'entity')
-      glossReferences += countTypeRefsInGlosses(eventTypes, typeId, personaId, 'entity')
-      glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'entity')
-
-      // Count annotations with this typeId
-      const annotationCount = await fastify.prisma.annotation.count({
-        where: {
-          personaId,
-          type: 'entity',
-          label: typeId
-        }
-      })
-
-      // Count world state type assignments
-      let worldAssignmentCount = 0
-      const worldState = await fastify.prisma.worldState.findFirst({
-        where: { userId: persona.userId, projectId: null }
-      })
-
-      if (worldState) {
-        const entities = asEntities(worldState.entities)
-        worldAssignmentCount = countTypeAssignments(entities, typeId, personaId)
-      }
-
-      return reply.send({
-        glossReferences,
-        annotationCount,
-        worldAssignmentCount
-      })
+      return reply.send(await service.getEntityTypeDeletionPreview(personaId, typeId))
     }
   )
 
   /**
    * Delete an entity type with reference cleanup.
-   * Converts typeRef items in glosses to plain text and clears related annotations/assignments.
    *
    * @route DELETE /api/personas/:personaId/ontology/entities/:typeId
    */
@@ -966,102 +426,16 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('delete', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot modify this Persona')
-      }
-
-      // Find and remove the type
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const targetType = entityTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Entity type', typeId)
-      }
-
-      const typeName = targetType.name
-      const updatedEntityTypes = entityTypes.filter(t => t.id !== typeId)
-
-      // Convert typeRefs in glosses across all types
-      let glossReferences = 0
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const eventTypes = asTypesWithGloss(persona.ontology.eventTypes)
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-
-      // Count before updating
-      glossReferences += countTypeRefsInGlosses(updatedEntityTypes, typeId, personaId, 'entity')
-      glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'entity')
-      glossReferences += countTypeRefsInGlosses(eventTypes, typeId, personaId, 'entity')
-      glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'entity')
-
-      // Update glosses
-      const cleanedEntityTypes = updateGlossesInTypes(updatedEntityTypes, typeId, personaId, 'entity', typeName)
-      const cleanedRoleTypes = updateGlossesInTypes(roleTypes, typeId, personaId, 'entity', typeName)
-      const cleanedEventTypes = updateGlossesInTypes(eventTypes, typeId, personaId, 'entity', typeName)
-      const cleanedRelationTypes = updateGlossesInTypes(relationTypes, typeId, personaId, 'entity', typeName)
-
-      // Delete annotations with this type
-      const deleteResult = await fastify.prisma.annotation.deleteMany({
-        where: {
-          personaId,
-          type: 'entity',
-          label: typeId
-        }
-      })
-
-      // Clean up world state type assignments
-      let worldAssignments = 0
-      const worldState = await fastify.prisma.worldState.findFirst({
-        where: { userId: persona.userId, projectId: null }
-      })
-
-      if (worldState) {
-        const entities = asEntities(worldState.entities)
-        worldAssignments = countTypeAssignments(entities, typeId, personaId)
-        const cleanedEntities = removeTypeAssignmentsFromEntities(entities, typeId, personaId)
-
-        await fastify.prisma.worldState.update({
-          where: { id: worldState.id },
-          data: {
-            entities: toJson(cleanedEntities)
-          }
-        })
-      }
-
-      // Update ontology
-      await fastify.prisma.ontology.update({
-        where: { personaId },
-        data: {
-          entityTypes: toJson(cleanedEntityTypes),
-          roleTypes: toJson(cleanedRoleTypes),
-          eventTypes: toJson(cleanedEventTypes),
-          relationTypes: toJson(cleanedRelationTypes)
-        }
-      })
-
-      return reply.send({
-        message: `Entity type "${typeName}" deleted successfully`,
-        cleanedUp: {
-          glossReferences,
-          annotations: deleteResult.count,
-          worldAssignments
-        }
-      })
+      return reply.send(await service.deleteEntityType(personaId, typeId))
     }
   )
 
   /**
-   * Get deletion preview for a role type.
+   * Deletion preview for a role type.
+   *
+   * @route GET /api/personas/:personaId/ontology/roles/:typeId/deletion-preview
    */
   fastify.get<{ Params: { personaId: string; typeId: string } }>(
     '/api/personas/:personaId/ontology/roles/:typeId/deletion-preview',
@@ -1085,72 +459,16 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('read', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot access this Persona')
-      }
-
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const targetType = roleTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Role type', typeId)
-      }
-
-      // Count gloss references
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const eventTypesForGloss = asTypesWithGloss(persona.ontology.eventTypes)
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'role')
-      glossReferences += countTypeRefsInGlosses(roleTypes.filter(t => t.id !== typeId), typeId, personaId, 'role')
-      glossReferences += countTypeRefsInGlosses(eventTypesForGloss, typeId, personaId, 'role')
-      glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'role')
-
-      // Count annotations with this role type
-      const annotationCount = await fastify.prisma.annotation.count({
-        where: {
-          personaId,
-          type: 'role',
-          label: typeId
-        }
-      })
-
-      // Count event types that use this role - need full EventType for roles property
-      const eventTypesRaw = persona.ontology.eventTypes
-      let eventRoleReferences = 0
-      if (Array.isArray(eventTypesRaw)) {
-        for (const eventType of eventTypesRaw) {
-          if (eventType && typeof eventType === 'object' && 'roles' in eventType) {
-            const roles = (eventType as { roles?: Array<{ roleTypeId: string }> }).roles
-            if (roles) {
-              eventRoleReferences += roles.filter(r => r.roleTypeId === typeId).length
-            }
-          }
-        }
-      }
-
-      return reply.send({
-        glossReferences,
-        annotationCount,
-        eventRoleReferences
-      })
+      return reply.send(await service.getRoleTypeDeletionPreview(personaId, typeId))
     }
   )
 
   /**
    * Delete a role type with reference cleanup.
+   *
+   * @route DELETE /api/personas/:personaId/ontology/roles/:typeId
    */
   fastify.delete<{ Params: { personaId: string; typeId: string } }>(
     '/api/personas/:personaId/ontology/roles/:typeId',
@@ -1177,108 +495,16 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('delete', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot modify this Persona')
-      }
-
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const targetType = roleTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Role type', typeId)
-      }
-
-      const typeName = targetType.name
-      const updatedRoleTypes = roleTypes.filter(t => t.id !== typeId)
-
-      // Count and update gloss references
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const eventTypesForGloss = asTypesWithGloss(persona.ontology.eventTypes)
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'role')
-      glossReferences += countTypeRefsInGlosses(updatedRoleTypes, typeId, personaId, 'role')
-      glossReferences += countTypeRefsInGlosses(eventTypesForGloss, typeId, personaId, 'role')
-      glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'role')
-
-      const cleanedEntityTypes = updateGlossesInTypes(entityTypes, typeId, personaId, 'role', typeName)
-      const cleanedRoleTypes = updateGlossesInTypes(updatedRoleTypes, typeId, personaId, 'role', typeName)
-      const cleanedEventTypesGloss = updateGlossesInTypes(eventTypesForGloss, typeId, personaId, 'role', typeName)
-      const cleanedRelationTypes = updateGlossesInTypes(relationTypes, typeId, personaId, 'role', typeName)
-
-      // Remove role from event type role slots - need full EventType for roles property
-      const eventTypesRaw = persona.ontology.eventTypes
-      let eventRoleReferences = 0
-      let cleanedEventTypes = cleanedEventTypesGloss
-      if (Array.isArray(eventTypesRaw)) {
-        for (const eventType of eventTypesRaw) {
-          if (eventType && typeof eventType === 'object' && 'roles' in eventType) {
-            const roles = (eventType as { roles?: Array<{ roleTypeId: string }> }).roles
-            if (roles) {
-              eventRoleReferences += roles.filter(r => r.roleTypeId === typeId).length
-            }
-          }
-        }
-        // Update cleanedEventTypes to also remove role references
-        cleanedEventTypes = cleanedEventTypesGloss.map(et => {
-          const rawEvent = eventTypesRaw.find(raw =>
-            raw && typeof raw === 'object' && 'id' in raw && (raw as { id: string }).id === et.id
-          )
-          if (rawEvent && typeof rawEvent === 'object' && 'roles' in rawEvent) {
-            const roles = (rawEvent as { roles?: Array<{ roleTypeId: string }> }).roles
-            if (roles) {
-              return { ...et, roles: roles.filter(r => r.roleTypeId !== typeId) }
-            }
-          }
-          return et
-        })
-      }
-
-      // Delete annotations
-      const deleteResult = await fastify.prisma.annotation.deleteMany({
-        where: {
-          personaId,
-          type: 'role',
-          label: typeId
-        }
-      })
-
-      // Update ontology
-      await fastify.prisma.ontology.update({
-        where: { personaId },
-        data: {
-          entityTypes: toJson(cleanedEntityTypes),
-          roleTypes: toJson(cleanedRoleTypes),
-          eventTypes: toJson(cleanedEventTypes),
-          relationTypes: toJson(cleanedRelationTypes)
-        }
-      })
-
-      return reply.send({
-        message: `Role type "${typeName}" deleted successfully`,
-        cleanedUp: {
-          glossReferences,
-          annotations: deleteResult.count,
-          eventRoleReferences
-        }
-      })
+      return reply.send(await service.deleteRoleType(personaId, typeId))
     }
   )
 
   /**
-   * Get deletion preview for an event type.
+   * Deletion preview for an event type.
+   *
+   * @route GET /api/personas/:personaId/ontology/events/:typeId/deletion-preview
    */
   fastify.get<{ Params: { personaId: string; typeId: string } }>(
     '/api/personas/:personaId/ontology/events/:typeId/deletion-preview',
@@ -1302,69 +528,16 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('read', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot access this Persona')
-      }
-
-      const eventTypes = asTypesWithGloss(persona.ontology.eventTypes)
-      const targetType = eventTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Event type', typeId)
-      }
-
-      // Count gloss references
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'event')
-      glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'event')
-      glossReferences += countTypeRefsInGlosses(eventTypes.filter(t => t.id !== typeId), typeId, personaId, 'event')
-      glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'event')
-
-      // Count annotations
-      const annotationCount = await fastify.prisma.annotation.count({
-        where: {
-          personaId,
-          type: 'event',
-          label: typeId
-        }
-      })
-
-      // Count world state event interpretations
-      let worldInterpretationCount = 0
-      const worldState = await fastify.prisma.worldState.findFirst({
-        where: { userId: persona.userId, projectId: null }
-      })
-
-      if (worldState) {
-        const events = asEvents(worldState.events)
-        worldInterpretationCount = countEventInterpretations(events, typeId, personaId)
-      }
-
-      return reply.send({
-        glossReferences,
-        annotationCount,
-        worldInterpretationCount
-      })
+      return reply.send(await service.getEventTypeDeletionPreview(personaId, typeId))
     }
   )
 
   /**
    * Delete an event type with reference cleanup.
+   *
+   * @route DELETE /api/personas/:personaId/ontology/events/:typeId
    */
   fastify.delete<{ Params: { personaId: string; typeId: string } }>(
     '/api/personas/:personaId/ontology/events/:typeId',
@@ -1391,99 +564,16 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('delete', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot modify this Persona')
-      }
-
-      const eventTypes = asTypesWithGloss(persona.ontology.eventTypes)
-      const targetType = eventTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Event type', typeId)
-      }
-
-      const typeName = targetType.name
-      const updatedEventTypes = eventTypes.filter(t => t.id !== typeId)
-
-      // Count and update gloss references
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'event')
-      glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'event')
-      glossReferences += countTypeRefsInGlosses(updatedEventTypes, typeId, personaId, 'event')
-      glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'event')
-
-      const cleanedEntityTypes = updateGlossesInTypes(entityTypes, typeId, personaId, 'event', typeName)
-      const cleanedRoleTypes = updateGlossesInTypes(roleTypes, typeId, personaId, 'event', typeName)
-      const cleanedEventTypes = updateGlossesInTypes(updatedEventTypes, typeId, personaId, 'event', typeName)
-      const cleanedRelationTypes = updateGlossesInTypes(relationTypes, typeId, personaId, 'event', typeName)
-
-      // Delete annotations
-      const deleteResult = await fastify.prisma.annotation.deleteMany({
-        where: {
-          personaId,
-          type: 'event',
-          label: typeId
-        }
-      })
-
-      // Clean up world state event interpretations
-      let worldInterpretations = 0
-      const worldState = await fastify.prisma.worldState.findFirst({
-        where: { userId: persona.userId, projectId: null }
-      })
-
-      if (worldState) {
-        const events = asEvents(worldState.events)
-        worldInterpretations = countEventInterpretations(events, typeId, personaId)
-        const cleanedEvents = removeEventInterpretationsFromEvents(events, typeId, personaId)
-
-        await fastify.prisma.worldState.update({
-          where: { id: worldState.id },
-          data: {
-            events: toJson(cleanedEvents)
-          }
-        })
-      }
-
-      // Update ontology
-      await fastify.prisma.ontology.update({
-        where: { personaId },
-        data: {
-          entityTypes: toJson(cleanedEntityTypes),
-          roleTypes: toJson(cleanedRoleTypes),
-          eventTypes: toJson(cleanedEventTypes),
-          relationTypes: toJson(cleanedRelationTypes)
-        }
-      })
-
-      return reply.send({
-        message: `Event type "${typeName}" deleted successfully`,
-        cleanedUp: {
-          glossReferences,
-          annotations: deleteResult.count,
-          worldInterpretations
-        }
-      })
+      return reply.send(await service.deleteEventType(personaId, typeId))
     }
   )
 
   /**
-   * Get deletion preview for a relation type.
+   * Deletion preview for a relation type.
+   *
+   * @route GET /api/personas/:personaId/ontology/relation-types/:typeId/deletion-preview
    */
   fastify.get<{ Params: { personaId: string; typeId: string } }>(
     '/api/personas/:personaId/ontology/relation-types/:typeId/deletion-preview',
@@ -1506,52 +596,16 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('read', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot access this Persona')
-      }
-
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-      const targetType = relationTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Relation type', typeId)
-      }
-
-      // Count gloss references
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const eventTypes = asTypesWithGloss(persona.ontology.eventTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'relation')
-      glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'relation')
-      glossReferences += countTypeRefsInGlosses(eventTypes, typeId, personaId, 'relation')
-      glossReferences += countTypeRefsInGlosses(relationTypes.filter(t => t.id !== typeId), typeId, personaId, 'relation')
-
-      // Note: Relation instances would need to be stored somewhere to count them
-      // For now, we return 0 as they're handled client-side
-      const relationInstanceCount = 0
-
-      return reply.send({
-        glossReferences,
-        relationInstanceCount
-      })
+      return reply.send(await service.getRelationTypeDeletionPreview(personaId, typeId))
     }
   )
 
   /**
    * Delete a relation type with reference cleanup.
+   *
+   * @route DELETE /api/personas/:personaId/ontology/relation-types/:typeId
    */
   fastify.delete<{ Params: { personaId: string; typeId: string } }>(
     '/api/personas/:personaId/ontology/relation-types/:typeId',
@@ -1576,64 +630,9 @@ const personasRoute: FastifyPluginAsync = async (fastify) => {
       }
     },
     async (request, reply) => {
+      const service = serviceFor(request)
       const { personaId, typeId } = request.params
-
-      const persona = await fastify.prisma.persona.findUnique({
-        where: { id: personaId },
-        include: { ontology: true }
-      })
-
-      if (!persona || !persona.ontology) {
-        throw new NotFoundError('Persona or ontology', personaId)
-      }
-
-      if (!request.ability) throw new ForbiddenError('No abilities defined')
-      if (!request.ability.can('delete', subject('Persona', persona))) {
-        throw new ForbiddenError('Cannot modify this Persona')
-      }
-
-      const relationTypes = asTypesWithGloss(persona.ontology.relationTypes)
-      const targetType = relationTypes.find(t => t.id === typeId)
-      if (!targetType) {
-        throw new NotFoundError('Relation type', typeId)
-      }
-
-      const typeName = targetType.name
-      const updatedRelationTypes = relationTypes.filter(t => t.id !== typeId)
-
-      // Count and update gloss references
-      const entityTypes = asTypesWithGloss(persona.ontology.entityTypes)
-      const roleTypes = asTypesWithGloss(persona.ontology.roleTypes)
-      const eventTypes = asTypesWithGloss(persona.ontology.eventTypes)
-
-      let glossReferences = 0
-      glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'relation')
-      glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'relation')
-      glossReferences += countTypeRefsInGlosses(eventTypes, typeId, personaId, 'relation')
-      glossReferences += countTypeRefsInGlosses(updatedRelationTypes, typeId, personaId, 'relation')
-
-      const cleanedEntityTypes = updateGlossesInTypes(entityTypes, typeId, personaId, 'relation', typeName)
-      const cleanedRoleTypes = updateGlossesInTypes(roleTypes, typeId, personaId, 'relation', typeName)
-      const cleanedEventTypes = updateGlossesInTypes(eventTypes, typeId, personaId, 'relation', typeName)
-      const cleanedRelationTypes = updateGlossesInTypes(updatedRelationTypes, typeId, personaId, 'relation', typeName)
-
-      // Update ontology
-      await fastify.prisma.ontology.update({
-        where: { personaId },
-        data: {
-          entityTypes: toJson(cleanedEntityTypes),
-          roleTypes: toJson(cleanedRoleTypes),
-          eventTypes: toJson(cleanedEventTypes),
-          relationTypes: toJson(cleanedRelationTypes)
-        }
-      })
-
-      return reply.send({
-        message: `Relation type "${typeName}" deleted successfully`,
-        cleanedUp: {
-          glossReferences
-        }
-      })
+      return reply.send(await service.deleteRelationType(personaId, typeId))
     }
   )
 }

--- a/server/src/services/persona-service.ts
+++ b/server/src/services/persona-service.ts
@@ -1,0 +1,1032 @@
+import { Persona, Prisma } from '@prisma/client'
+import { accessibleBy } from '@casl/prisma'
+import { subject } from '@casl/ability'
+import type { AppAbility } from '../lib/abilities.js'
+import { NotFoundError, ForbiddenError } from '../lib/errors.js'
+import { isDemoModeEnabled } from '../lib/demo-flags.js'
+import { isSingleUserMode } from './user-service.js'
+import {
+  PersonaRepository,
+  PersonaWithOntology
+} from '../repositories/PersonaRepository.js'
+import {
+  updateGlossesInTypes,
+  countTypeRefsInGlosses,
+  removeTypeAssignmentsFromEntities,
+  removeEventInterpretationsFromEvents,
+  countTypeAssignments,
+  countEventInterpretations
+} from '../lib/reference-cleanup.js'
+import { asTypesWithGloss, asEntities, asEvents } from '../lib/prisma-json.js'
+
+/**
+ * Converts a typed array to Prisma.InputJsonValue for storage in JSON columns.
+ * Prisma JSON columns accept any serializable value at runtime; this bridges
+ * the TypeScript gap without an unsafe cast.
+ */
+function toJson(value: unknown): Prisma.InputJsonValue {
+  return value as Prisma.InputJsonValue
+}
+
+/** RefType categories used by the gloss reference cleanup helpers. */
+type RefType = 'entity' | 'role' | 'event' | 'relation'
+
+/** Maps a type-deletion endpoint to the ontology array it primarily targets. */
+type TypeCategory = 'entity' | 'role' | 'event' | 'relation'
+
+/**
+ * API-facing ontology shape.
+ *
+ * The database stores `entityTypes` / `roleTypes` / `eventTypes`; the API
+ * exposes them as `entities` / `roles` / `events` and always returns an empty
+ * `relations` array. Dates are ISO strings.
+ */
+export interface OntologyResponse {
+  id: string
+  personaId: string
+  entities: unknown[]
+  roles: unknown[]
+  events: unknown[]
+  relationTypes: unknown[]
+  relations: never[]
+  createdAt: string
+  updatedAt: string
+}
+
+/** Validated, coerced fields for creating a persona. */
+export interface CreatePersonaInput {
+  name: string
+  role: string
+  informationNeed: string
+  details?: string
+  projectId?: string
+  isSystemGenerated?: boolean
+  hidden?: boolean
+}
+
+/** Validated fields for updating a persona (all optional). */
+export interface UpdatePersonaInput {
+  name?: string
+  role?: string
+  informationNeed?: string
+  details?: string
+  isSystemGenerated?: boolean
+  hidden?: boolean
+}
+
+/** Request body shape for the ontology update endpoint. */
+export interface OntologyUpdateInput {
+  entities?: unknown[]
+  roles?: unknown[]
+  events?: unknown[]
+  relationTypes?: unknown[]
+  relations?: unknown[]
+}
+
+/** Counts returned by the persona deletion preview. */
+export interface PersonaDeletionPreview {
+  typeCount: number
+  annotationCount: number
+  summaryCount: number
+  worldAssignmentCount: number
+}
+
+/**
+ * Owns persona business rules and RBAC, delegating all data access to a
+ * PersonaRepository. Construct one per request from the request-scoped CASL
+ * ability and the authenticated user's id and system role.
+ *
+ * The service performs every authorization decision (mode-branch selection,
+ * `accessibleBy` filters, instance-level `can()` checks, the create
+ * pre-check, and the `isSystemGenerated` coercion). The repository performs
+ * none.
+ *
+ * @example
+ * ```typescript
+ * const service = new PersonaService(repository, request.ability, request.user?.id, request.user?.systemRole)
+ * const personas = await service.list()
+ * ```
+ */
+export class PersonaService {
+  constructor(
+    private readonly repository: PersonaRepository,
+    private readonly ability: AppAbility | null,
+    private readonly userId: string | undefined,
+    private readonly systemRole: string | undefined
+  ) {}
+
+  /**
+   * Asserts that a CASL ability is present, returning it narrowed.
+   *
+   * Mirrors the per-request `if (!request.ability) throw new ForbiddenError(...)`
+   * guard the route used on every authenticated handler.
+   */
+  private requireAbility(): AppAbility {
+    if (!this.ability) {
+      throw new ForbiddenError('No abilities defined')
+    }
+    return this.ability
+  }
+
+  /**
+   * Lists the personas visible to the caller.
+   *
+   * Applies the four mode branches in order:
+   * - single-user mode: every non-hidden persona;
+   * - unauthenticated: non-hidden system personas;
+   * - demo mode: every system persona (hidden or not);
+   * - authenticated: non-hidden personas the caller may read (CASL).
+   *
+   * @returns the visible personas, newest first
+   */
+  async list(): Promise<Persona[]> {
+    if (isSingleUserMode()) {
+      return this.repository.findManyForList({ hidden: false })
+    }
+
+    if (!this.userId || !this.ability) {
+      return this.repository.findManyForList({ isSystemGenerated: true, hidden: false })
+    }
+
+    if (isDemoModeEnabled()) {
+      return this.repository.findManyForList({ isSystemGenerated: true })
+    }
+
+    return this.repository.findManyForList({
+      AND: [
+        { hidden: false },
+        accessibleBy(this.ability, 'read').Persona
+      ]
+    })
+  }
+
+  /**
+   * Creates a persona with an empty ontology.
+   *
+   * Verifies the caller may create a persona in the target scope, then coerces
+   * `isSystemGenerated` to false for non-admins (only system_admin may set it).
+   *
+   * @param input - validated, coerced create fields
+   * @returns the created persona
+   * @throws {ForbiddenError} when no ability is present or the create is denied
+   */
+  async create(input: CreatePersonaInput): Promise<Persona> {
+    const ability = this.requireAbility()
+    const userId = this.userId!
+    const projectId = input.projectId ?? null
+
+    const candidate = subject('Persona', { userId, projectId })
+    if (!ability.can('create', candidate)) {
+      throw new ForbiddenError('Cannot create Persona in this scope')
+    }
+
+    // Only system_admin may flag a persona as system-generated, since system
+    // personas are visible to unauthenticated visitors via the unauthenticated
+    // list branch. A non-admin attempt is silently coerced to false rather
+    // than 403 so clients that always send the field still succeed.
+    const isSystemGenerated = this.systemRole === 'system_admin'
+      ? input.isSystemGenerated
+      : false
+
+    return this.repository.createWithOntology({
+      name: input.name,
+      role: input.role,
+      informationNeed: input.informationNeed,
+      details: input.details || null,
+      isSystemGenerated,
+      hidden: input.hidden,
+      user: { connect: { id: userId } },
+      ...(projectId ? { project: { connect: { id: projectId } } } : {}),
+      ontology: {
+        create: {
+          entityTypes: [],
+          eventTypes: [],
+          roleTypes: [],
+          relationTypes: []
+        }
+      }
+    })
+  }
+
+  /**
+   * Gets a persona by ID, enforcing read access.
+   *
+   * Unauthenticated callers may only read non-hidden system personas; for them
+   * a non-system or hidden persona is reported as not found. Authenticated
+   * callers must pass the CASL read check.
+   *
+   * @param id - Persona UUID
+   * @returns the persona
+   * @throws {NotFoundError} when the persona does not exist or is not visible to an anonymous caller
+   * @throws {ForbiddenError} when an authenticated caller lacks read access
+   */
+  async getById(id: string): Promise<Persona> {
+    const persona = await this.repository.findById(id)
+    if (!persona) {
+      throw new NotFoundError('Persona', id)
+    }
+
+    if (!this.userId || !this.ability) {
+      if (!persona.isSystemGenerated || persona.hidden) {
+        throw new NotFoundError('Persona', id)
+      }
+      return persona
+    }
+
+    if (!this.ability.can('read', subject('Persona', persona))) {
+      throw new ForbiddenError('Access denied')
+    }
+
+    return persona
+  }
+
+  /**
+   * Updates a persona after verifying update access.
+   *
+   * Strips `isSystemGenerated` from non-admin updates so a regular user cannot
+   * publish their persona to anonymous visitors.
+   *
+   * @param id - Persona UUID
+   * @param input - validated update fields
+   * @returns the updated persona
+   * @throws {NotFoundError} when the persona does not exist
+   * @throws {ForbiddenError} when the caller lacks update access
+   */
+  async update(id: string, input: UpdatePersonaInput): Promise<Persona> {
+    const ability = this.requireAbility()
+
+    const existing = await this.repository.findById(id)
+    if (!existing) {
+      throw new NotFoundError('Persona', id)
+    }
+
+    if (!ability.can('update', subject('Persona', existing))) {
+      throw new ForbiddenError('Cannot update this Persona')
+    }
+
+    const updatePayload: UpdatePersonaInput = { ...input }
+    if (this.systemRole !== 'system_admin') {
+      delete updatePayload.isSystemGenerated
+    }
+
+    try {
+      return await this.repository.update(id, updatePayload)
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
+        throw new NotFoundError('Persona', id)
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Computes the deletion preview for a persona: counts of ontology types,
+   * annotations, summaries, and personal world-state assignments that the
+   * delete would affect.
+   *
+   * @param id - Persona UUID
+   * @returns the affected-item counts
+   * @throws {NotFoundError} when the persona does not exist
+   * @throws {ForbiddenError} when the caller lacks delete access
+   */
+  async getDeletionPreview(id: string): Promise<PersonaDeletionPreview> {
+    const ability = this.requireAbility()
+
+    const persona = await this.repository.findByIdWithOntology(id)
+    if (!persona) {
+      throw new NotFoundError('Persona', id)
+    }
+
+    if (!ability.can('delete', subject('Persona', persona))) {
+      throw new ForbiddenError('Cannot access this Persona')
+    }
+
+    const entityTypes = Array.isArray(persona.ontology?.entityTypes) ? persona.ontology.entityTypes : []
+    const roleTypes = Array.isArray(persona.ontology?.roleTypes) ? persona.ontology.roleTypes : []
+    const eventTypes = Array.isArray(persona.ontology?.eventTypes) ? persona.ontology.eventTypes : []
+    const relationTypes = Array.isArray(persona.ontology?.relationTypes) ? persona.ontology.relationTypes : []
+    const typeCount = entityTypes.length + roleTypes.length + eventTypes.length + relationTypes.length
+
+    const annotationCount = await this.repository.countAnnotations({ personaId: id })
+    const summaryCount = await this.repository.countVideoSummaries(id)
+
+    let worldAssignmentCount = 0
+    const worldState = await this.repository.findPersonalWorldState(persona.userId)
+    if (worldState) {
+      const entities = (worldState.entities as Array<{ typeAssignments?: Array<{ personaId: string }> }>) || []
+      for (const entity of entities) {
+        worldAssignmentCount += (entity.typeAssignments || []).filter(a => a.personaId === id).length
+      }
+
+      const events = (worldState.events as Array<{ personaInterpretations?: Array<{ personaId: string }> }>) || []
+      for (const event of events) {
+        worldAssignmentCount += (event.personaInterpretations || []).filter(i => i.personaId === id).length
+      }
+
+      const entityCollections = (worldState.entityCollections as Array<{ typeAssignments?: Array<{ personaId: string }> }>) || []
+      for (const collection of entityCollections) {
+        worldAssignmentCount += (collection.typeAssignments || []).filter(a => a.personaId === id).length
+      }
+
+      const eventCollections = (worldState.eventCollections as Array<{ typeAssignments?: Array<{ personaId: string }> }>) || []
+      for (const collection of eventCollections) {
+        worldAssignmentCount += (collection.typeAssignments || []).filter(a => a.personaId === id).length
+      }
+    }
+
+    return { typeCount, annotationCount, summaryCount, worldAssignmentCount }
+  }
+
+  /**
+   * Deletes a persona and cleans the owner's personal world state of the
+   * persona's type assignments and interpretations before removing the row.
+   *
+   * @param id - Persona UUID
+   * @throws {NotFoundError} when the persona does not exist
+   * @throws {ForbiddenError} when the caller lacks delete access
+   */
+  async delete(id: string): Promise<void> {
+    const ability = this.requireAbility()
+
+    const existing = await this.repository.findById(id)
+    if (!existing) {
+      throw new NotFoundError('Persona', id)
+    }
+
+    if (!ability.can('delete', subject('Persona', existing))) {
+      throw new ForbiddenError('Cannot delete this Persona')
+    }
+
+    const worldState = await this.repository.findPersonalWorldState(existing.userId)
+    if (worldState) {
+      interface EntityWithAssignments {
+        typeAssignments?: Array<{ personaId: string; [key: string]: unknown }>
+        [key: string]: unknown
+      }
+      interface EventWithInterpretations {
+        personaInterpretations?: Array<{ personaId: string; [key: string]: unknown }>
+        [key: string]: unknown
+      }
+      interface CollectionWithAssignments {
+        typeAssignments?: Array<{ personaId: string; [key: string]: unknown }>
+        [key: string]: unknown
+      }
+
+      const entities = (worldState.entities as EntityWithAssignments[]) || []
+      const cleanedEntities = entities.map(entity => ({
+        ...entity,
+        typeAssignments: (entity.typeAssignments || []).filter(a => a.personaId !== id)
+      }))
+
+      const events = (worldState.events as EventWithInterpretations[]) || []
+      const cleanedEvents = events.map(event => ({
+        ...event,
+        personaInterpretations: (event.personaInterpretations || []).filter(i => i.personaId !== id)
+      }))
+
+      const entityCollections = (worldState.entityCollections as CollectionWithAssignments[]) || []
+      const cleanedEntityCollections = entityCollections.map(collection => ({
+        ...collection,
+        typeAssignments: (collection.typeAssignments || []).filter(a => a.personaId !== id)
+      }))
+
+      const eventCollections = (worldState.eventCollections as CollectionWithAssignments[]) || []
+      const cleanedEventCollections = eventCollections.map(collection => ({
+        ...collection,
+        typeAssignments: (collection.typeAssignments || []).filter(a => a.personaId !== id)
+      }))
+
+      await this.repository.updateWorldState(worldState.id, {
+        entities: toJson(cleanedEntities),
+        events: toJson(cleanedEvents),
+        entityCollections: toJson(cleanedEntityCollections),
+        eventCollections: toJson(cleanedEventCollections)
+      })
+    }
+
+    try {
+      await this.repository.delete(id)
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
+        throw new NotFoundError('Persona', id)
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Gets a persona's ontology mapped to the API response shape.
+   *
+   * Read access mirrors getById, with the demo-mode widening: in demo mode any
+   * caller may read a system persona's ontology.
+   *
+   * @param id - Persona UUID
+   * @returns the ontology in API shape
+   * @throws {NotFoundError} when the persona or its ontology does not exist, or is not visible to an anonymous caller
+   * @throws {ForbiddenError} when an authenticated caller lacks read access
+   */
+  async getOntology(id: string): Promise<OntologyResponse> {
+    const persona = await this.repository.findByIdWithOntology(id)
+    if (!persona || !persona.ontology) {
+      throw new NotFoundError('Persona or ontology', id)
+    }
+
+    if (!this.userId || !this.ability) {
+      if (!persona.isSystemGenerated || persona.hidden) {
+        throw new NotFoundError('Persona or ontology', id)
+      }
+    } else if (!this.ability.can('read', subject('Persona', persona))) {
+      // Demo mode widens read access to seeded system personas so the public
+      // tour catalogue can fetch their ontologies.
+      if (!isDemoModeEnabled() || !persona.isSystemGenerated) {
+        throw new ForbiddenError('Access denied')
+      }
+    }
+
+    return this.mapOntologyResponse(persona.ontology)
+  }
+
+  /**
+   * Batch-fetches ontologies for many personas, applying the same per-persona
+   * read rules as getOntology. Personas that are missing, have no ontology, or
+   * are not readable are omitted.
+   *
+   * @param personaIds - Persona UUIDs to fetch
+   * @returns the readable ontologies, in API shape
+   */
+  async getOntologies(personaIds: string[]): Promise<OntologyResponse[]> {
+    if (personaIds.length === 0) {
+      return []
+    }
+
+    const personas = await this.repository.findManyWithOntology(personaIds)
+    const result: OntologyResponse[] = []
+
+    for (const persona of personas) {
+      if (!persona.ontology) continue
+
+      if (!this.userId || !this.ability) {
+        if (!persona.isSystemGenerated || persona.hidden) continue
+      } else if (!this.ability.can('read', subject('Persona', persona))) {
+        if (!isDemoModeEnabled() || !persona.isSystemGenerated) continue
+      }
+
+      result.push(this.mapOntologyResponse(persona.ontology))
+    }
+
+    return result
+  }
+
+  /**
+   * Updates a persona's ontology from the API request body and returns the
+   * updated ontology in API shape. Fields omitted from the body are preserved.
+   *
+   * @param id - Persona UUID
+   * @param input - ontology update body (entities/roles/events/relationTypes)
+   * @returns the updated ontology in API shape
+   * @throws {NotFoundError} when the persona or its ontology does not exist
+   * @throws {ForbiddenError} when the caller lacks update access
+   */
+  async updateOntology(id: string, input: OntologyUpdateInput): Promise<OntologyResponse> {
+    const ability = this.requireAbility()
+
+    const persona = await this.repository.findByIdWithOntology(id)
+    if (!persona || !persona.ontology) {
+      throw new NotFoundError('Persona or ontology', id)
+    }
+
+    if (!ability.can('update', subject('Persona', persona))) {
+      throw new ForbiddenError('Cannot update this Persona')
+    }
+
+    const updated = await this.repository.updateOntology(id, {
+      entityTypes: input.entities !== undefined ? (input.entities as Prisma.InputJsonValue) : (persona.ontology.entityTypes ?? undefined),
+      roleTypes: input.roles !== undefined ? (input.roles as Prisma.InputJsonValue) : (persona.ontology.roleTypes ?? undefined),
+      eventTypes: input.events !== undefined ? (input.events as Prisma.InputJsonValue) : (persona.ontology.eventTypes ?? undefined),
+      relationTypes: input.relationTypes !== undefined ? (input.relationTypes as Prisma.InputJsonValue) : (persona.ontology.relationTypes ?? undefined)
+    })
+
+    return this.mapOntologyResponse(updated)
+  }
+
+  /**
+   * Loads a persona with its ontology and enforces read access for the type
+   * deletion-preview endpoints. Demo-mode widening does not apply here (these
+   * endpoints require authentication).
+   *
+   * @throws {NotFoundError} when the persona or its ontology does not exist
+   * @throws {ForbiddenError} when no ability is present or read access is denied
+   */
+  private async loadForTypeRead(personaId: string): Promise<PersonaWithOntology> {
+    const persona = await this.repository.findByIdWithOntology(personaId)
+    if (!persona || !persona.ontology) {
+      throw new NotFoundError('Persona or ontology', personaId)
+    }
+
+    const ability = this.requireAbility()
+    if (!ability.can('read', subject('Persona', persona))) {
+      throw new ForbiddenError('Cannot access this Persona')
+    }
+
+    return persona
+  }
+
+  /**
+   * Loads a persona with its ontology and enforces delete access for the type
+   * deletion endpoints.
+   *
+   * @throws {NotFoundError} when the persona or its ontology does not exist
+   * @throws {ForbiddenError} when no ability is present or delete access is denied
+   */
+  private async loadForTypeDelete(personaId: string): Promise<PersonaWithOntology> {
+    const persona = await this.repository.findByIdWithOntology(personaId)
+    if (!persona || !persona.ontology) {
+      throw new NotFoundError('Persona or ontology', personaId)
+    }
+
+    const ability = this.requireAbility()
+    if (!ability.can('delete', subject('Persona', persona))) {
+      throw new ForbiddenError('Cannot modify this Persona')
+    }
+
+    return persona
+  }
+
+  /**
+   * Counts gloss references to a type across all four ontology type arrays,
+   * with the target array filtered to exclude the type itself.
+   */
+  private countGlossRefsAcrossOntology(
+    ontology: PersonaWithOntology['ontology'],
+    personaId: string,
+    typeId: string,
+    refType: RefType,
+    selfCategory: TypeCategory
+  ): number {
+    const entityTypes = asTypesWithGloss(ontology!.entityTypes)
+    const roleTypes = asTypesWithGloss(ontology!.roleTypes)
+    const eventTypes = asTypesWithGloss(ontology!.eventTypes)
+    const relationTypes = asTypesWithGloss(ontology!.relationTypes)
+
+    const exclude = (types: typeof entityTypes, category: TypeCategory) =>
+      category === selfCategory ? types.filter(t => t.id !== typeId) : types
+
+    let count = 0
+    count += countTypeRefsInGlosses(exclude(entityTypes, 'entity'), typeId, personaId, refType)
+    count += countTypeRefsInGlosses(exclude(roleTypes, 'role'), typeId, personaId, refType)
+    count += countTypeRefsInGlosses(exclude(eventTypes, 'event'), typeId, personaId, refType)
+    count += countTypeRefsInGlosses(exclude(relationTypes, 'relation'), typeId, personaId, refType)
+    return count
+  }
+
+  /**
+   * Deletion preview for an entity type.
+   *
+   * @returns gloss reference, annotation, and world-assignment counts
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when read access is denied
+   */
+  async getEntityTypeDeletionPreview(
+    personaId: string,
+    typeId: string
+  ): Promise<{ glossReferences: number; annotationCount: number; worldAssignmentCount: number }> {
+    const persona = await this.loadForTypeRead(personaId)
+
+    const entityTypes = asTypesWithGloss(persona.ontology!.entityTypes)
+    if (!entityTypes.find(t => t.id === typeId)) {
+      throw new NotFoundError('Entity type', typeId)
+    }
+
+    const glossReferences = this.countGlossRefsAcrossOntology(persona.ontology, personaId, typeId, 'entity', 'entity')
+
+    const annotationCount = await this.repository.countAnnotations({
+      personaId,
+      type: 'entity',
+      label: typeId
+    })
+
+    let worldAssignmentCount = 0
+    const worldState = await this.repository.findPersonalWorldState(persona.userId)
+    if (worldState) {
+      const entities = asEntities(worldState.entities)
+      worldAssignmentCount = countTypeAssignments(entities, typeId, personaId)
+    }
+
+    return { glossReferences, annotationCount, worldAssignmentCount }
+  }
+
+  /**
+   * Deletes an entity type, converting gloss references to text, deleting
+   * matching annotations, and cleaning the personal world state.
+   *
+   * @returns the success message and the cleaned-up counts
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when delete access is denied
+   */
+  async deleteEntityType(
+    personaId: string,
+    typeId: string
+  ): Promise<{ message: string; cleanedUp: { glossReferences: number; annotations: number; worldAssignments: number } }> {
+    const persona = await this.loadForTypeDelete(personaId)
+    const ontology = persona.ontology!
+
+    const entityTypes = asTypesWithGloss(ontology.entityTypes)
+    const targetType = entityTypes.find(t => t.id === typeId)
+    if (!targetType) {
+      throw new NotFoundError('Entity type', typeId)
+    }
+
+    const typeName = targetType.name
+    const updatedEntityTypes = entityTypes.filter(t => t.id !== typeId)
+
+    const roleTypes = asTypesWithGloss(ontology.roleTypes)
+    const eventTypes = asTypesWithGloss(ontology.eventTypes)
+    const relationTypes = asTypesWithGloss(ontology.relationTypes)
+
+    let glossReferences = 0
+    glossReferences += countTypeRefsInGlosses(updatedEntityTypes, typeId, personaId, 'entity')
+    glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'entity')
+    glossReferences += countTypeRefsInGlosses(eventTypes, typeId, personaId, 'entity')
+    glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'entity')
+
+    const cleanedEntityTypes = updateGlossesInTypes(updatedEntityTypes, typeId, personaId, 'entity', typeName)
+    const cleanedRoleTypes = updateGlossesInTypes(roleTypes, typeId, personaId, 'entity', typeName)
+    const cleanedEventTypes = updateGlossesInTypes(eventTypes, typeId, personaId, 'entity', typeName)
+    const cleanedRelationTypes = updateGlossesInTypes(relationTypes, typeId, personaId, 'entity', typeName)
+
+    const deleteResult = await this.repository.deleteAnnotations({
+      personaId,
+      type: 'entity',
+      label: typeId
+    })
+
+    let worldAssignments = 0
+    const worldState = await this.repository.findPersonalWorldState(persona.userId)
+    if (worldState) {
+      const entities = asEntities(worldState.entities)
+      worldAssignments = countTypeAssignments(entities, typeId, personaId)
+      const cleanedEntities = removeTypeAssignmentsFromEntities(entities, typeId, personaId)
+      await this.repository.updateWorldState(worldState.id, {
+        entities: toJson(cleanedEntities)
+      })
+    }
+
+    await this.repository.updateOntology(personaId, {
+      entityTypes: toJson(cleanedEntityTypes),
+      roleTypes: toJson(cleanedRoleTypes),
+      eventTypes: toJson(cleanedEventTypes),
+      relationTypes: toJson(cleanedRelationTypes)
+    })
+
+    return {
+      message: `Entity type "${typeName}" deleted successfully`,
+      cleanedUp: {
+        glossReferences,
+        annotations: deleteResult.count,
+        worldAssignments
+      }
+    }
+  }
+
+  /**
+   * Deletion preview for a role type.
+   *
+   * @returns gloss reference, annotation, and event-role reference counts
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when read access is denied
+   */
+  async getRoleTypeDeletionPreview(
+    personaId: string,
+    typeId: string
+  ): Promise<{ glossReferences: number; annotationCount: number; eventRoleReferences: number }> {
+    const persona = await this.loadForTypeRead(personaId)
+    const ontology = persona.ontology!
+
+    const roleTypes = asTypesWithGloss(ontology.roleTypes)
+    if (!roleTypes.find(t => t.id === typeId)) {
+      throw new NotFoundError('Role type', typeId)
+    }
+
+    const glossReferences = this.countGlossRefsAcrossOntology(ontology, personaId, typeId, 'role', 'role')
+
+    const annotationCount = await this.repository.countAnnotations({
+      personaId,
+      type: 'role',
+      label: typeId
+    })
+
+    const eventRoleReferences = this.countEventRoleReferences(ontology.eventTypes, typeId)
+
+    return { glossReferences, annotationCount, eventRoleReferences }
+  }
+
+  /**
+   * Deletes a role type, converting gloss references to text, removing the role
+   * from event-type role slots, and deleting matching annotations.
+   *
+   * @returns the success message and the cleaned-up counts
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when delete access is denied
+   */
+  async deleteRoleType(
+    personaId: string,
+    typeId: string
+  ): Promise<{ message: string; cleanedUp: { glossReferences: number; annotations: number; eventRoleReferences: number } }> {
+    const persona = await this.loadForTypeDelete(personaId)
+    const ontology = persona.ontology!
+
+    const roleTypes = asTypesWithGloss(ontology.roleTypes)
+    const targetType = roleTypes.find(t => t.id === typeId)
+    if (!targetType) {
+      throw new NotFoundError('Role type', typeId)
+    }
+
+    const typeName = targetType.name
+    const updatedRoleTypes = roleTypes.filter(t => t.id !== typeId)
+
+    const entityTypes = asTypesWithGloss(ontology.entityTypes)
+    const eventTypesForGloss = asTypesWithGloss(ontology.eventTypes)
+    const relationTypes = asTypesWithGloss(ontology.relationTypes)
+
+    let glossReferences = 0
+    glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'role')
+    glossReferences += countTypeRefsInGlosses(updatedRoleTypes, typeId, personaId, 'role')
+    glossReferences += countTypeRefsInGlosses(eventTypesForGloss, typeId, personaId, 'role')
+    glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'role')
+
+    const cleanedEntityTypes = updateGlossesInTypes(entityTypes, typeId, personaId, 'role', typeName)
+    const cleanedRoleTypes = updateGlossesInTypes(updatedRoleTypes, typeId, personaId, 'role', typeName)
+    const cleanedEventTypesGloss = updateGlossesInTypes(eventTypesForGloss, typeId, personaId, 'role', typeName)
+    const cleanedRelationTypes = updateGlossesInTypes(relationTypes, typeId, personaId, 'role', typeName)
+
+    // Remove the role from event-type role slots, preserving every other field
+    // on each event type. The raw event types carry the `roles` array, which
+    // the gloss-only mapping above does not.
+    const eventTypesRaw = ontology.eventTypes
+    const eventRoleReferences = this.countEventRoleReferences(eventTypesRaw, typeId)
+    let cleanedEventTypes = cleanedEventTypesGloss
+    if (Array.isArray(eventTypesRaw)) {
+      cleanedEventTypes = cleanedEventTypesGloss.map(et => {
+        const rawEvent = eventTypesRaw.find(raw =>
+          raw && typeof raw === 'object' && 'id' in raw && (raw as { id: string }).id === et.id
+        )
+        if (rawEvent && typeof rawEvent === 'object' && 'roles' in rawEvent) {
+          const roles = (rawEvent as { roles?: Array<{ roleTypeId: string }> }).roles
+          if (roles) {
+            return { ...et, roles: roles.filter(r => r.roleTypeId !== typeId) }
+          }
+        }
+        return et
+      })
+    }
+
+    const deleteResult = await this.repository.deleteAnnotations({
+      personaId,
+      type: 'role',
+      label: typeId
+    })
+
+    await this.repository.updateOntology(personaId, {
+      entityTypes: toJson(cleanedEntityTypes),
+      roleTypes: toJson(cleanedRoleTypes),
+      eventTypes: toJson(cleanedEventTypes),
+      relationTypes: toJson(cleanedRelationTypes)
+    })
+
+    return {
+      message: `Role type "${typeName}" deleted successfully`,
+      cleanedUp: {
+        glossReferences,
+        annotations: deleteResult.count,
+        eventRoleReferences
+      }
+    }
+  }
+
+  /**
+   * Counts the references to a role type across event-type role slots in a raw
+   * ontology event-types JSON value.
+   */
+  private countEventRoleReferences(eventTypesRaw: Prisma.JsonValue, roleTypeId: string): number {
+    let count = 0
+    if (Array.isArray(eventTypesRaw)) {
+      for (const eventType of eventTypesRaw) {
+        if (eventType && typeof eventType === 'object' && 'roles' in eventType) {
+          const roles = (eventType as { roles?: Array<{ roleTypeId: string }> }).roles
+          if (roles) {
+            count += roles.filter(r => r.roleTypeId === roleTypeId).length
+          }
+        }
+      }
+    }
+    return count
+  }
+
+  /**
+   * Deletion preview for an event type.
+   *
+   * @returns gloss reference, annotation, and world-interpretation counts
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when read access is denied
+   */
+  async getEventTypeDeletionPreview(
+    personaId: string,
+    typeId: string
+  ): Promise<{ glossReferences: number; annotationCount: number; worldInterpretationCount: number }> {
+    const persona = await this.loadForTypeRead(personaId)
+    const ontology = persona.ontology!
+
+    const eventTypes = asTypesWithGloss(ontology.eventTypes)
+    if (!eventTypes.find(t => t.id === typeId)) {
+      throw new NotFoundError('Event type', typeId)
+    }
+
+    const glossReferences = this.countGlossRefsAcrossOntology(ontology, personaId, typeId, 'event', 'event')
+
+    const annotationCount = await this.repository.countAnnotations({
+      personaId,
+      type: 'event',
+      label: typeId
+    })
+
+    let worldInterpretationCount = 0
+    const worldState = await this.repository.findPersonalWorldState(persona.userId)
+    if (worldState) {
+      const events = asEvents(worldState.events)
+      worldInterpretationCount = countEventInterpretations(events, typeId, personaId)
+    }
+
+    return { glossReferences, annotationCount, worldInterpretationCount }
+  }
+
+  /**
+   * Deletes an event type, converting gloss references to text, deleting
+   * matching annotations, and cleaning event interpretations from the personal
+   * world state.
+   *
+   * @returns the success message and the cleaned-up counts
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when delete access is denied
+   */
+  async deleteEventType(
+    personaId: string,
+    typeId: string
+  ): Promise<{ message: string; cleanedUp: { glossReferences: number; annotations: number; worldInterpretations: number } }> {
+    const persona = await this.loadForTypeDelete(personaId)
+    const ontology = persona.ontology!
+
+    const eventTypes = asTypesWithGloss(ontology.eventTypes)
+    const targetType = eventTypes.find(t => t.id === typeId)
+    if (!targetType) {
+      throw new NotFoundError('Event type', typeId)
+    }
+
+    const typeName = targetType.name
+    const updatedEventTypes = eventTypes.filter(t => t.id !== typeId)
+
+    const entityTypes = asTypesWithGloss(ontology.entityTypes)
+    const roleTypes = asTypesWithGloss(ontology.roleTypes)
+    const relationTypes = asTypesWithGloss(ontology.relationTypes)
+
+    let glossReferences = 0
+    glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'event')
+    glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'event')
+    glossReferences += countTypeRefsInGlosses(updatedEventTypes, typeId, personaId, 'event')
+    glossReferences += countTypeRefsInGlosses(relationTypes, typeId, personaId, 'event')
+
+    const cleanedEntityTypes = updateGlossesInTypes(entityTypes, typeId, personaId, 'event', typeName)
+    const cleanedRoleTypes = updateGlossesInTypes(roleTypes, typeId, personaId, 'event', typeName)
+    const cleanedEventTypes = updateGlossesInTypes(updatedEventTypes, typeId, personaId, 'event', typeName)
+    const cleanedRelationTypes = updateGlossesInTypes(relationTypes, typeId, personaId, 'event', typeName)
+
+    const deleteResult = await this.repository.deleteAnnotations({
+      personaId,
+      type: 'event',
+      label: typeId
+    })
+
+    let worldInterpretations = 0
+    const worldState = await this.repository.findPersonalWorldState(persona.userId)
+    if (worldState) {
+      const events = asEvents(worldState.events)
+      worldInterpretations = countEventInterpretations(events, typeId, personaId)
+      const cleanedEvents = removeEventInterpretationsFromEvents(events, typeId, personaId)
+      await this.repository.updateWorldState(worldState.id, {
+        events: toJson(cleanedEvents)
+      })
+    }
+
+    await this.repository.updateOntology(personaId, {
+      entityTypes: toJson(cleanedEntityTypes),
+      roleTypes: toJson(cleanedRoleTypes),
+      eventTypes: toJson(cleanedEventTypes),
+      relationTypes: toJson(cleanedRelationTypes)
+    })
+
+    return {
+      message: `Event type "${typeName}" deleted successfully`,
+      cleanedUp: {
+        glossReferences,
+        annotations: deleteResult.count,
+        worldInterpretations
+      }
+    }
+  }
+
+  /**
+   * Deletion preview for a relation type.
+   *
+   * Relation instances are tracked client-side, so the instance count is
+   * always 0.
+   *
+   * @returns gloss reference count and the (always-zero) relation instance count
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when read access is denied
+   */
+  async getRelationTypeDeletionPreview(
+    personaId: string,
+    typeId: string
+  ): Promise<{ glossReferences: number; relationInstanceCount: number }> {
+    const persona = await this.loadForTypeRead(personaId)
+    const ontology = persona.ontology!
+
+    const relationTypes = asTypesWithGloss(ontology.relationTypes)
+    if (!relationTypes.find(t => t.id === typeId)) {
+      throw new NotFoundError('Relation type', typeId)
+    }
+
+    const glossReferences = this.countGlossRefsAcrossOntology(ontology, personaId, typeId, 'relation', 'relation')
+
+    return { glossReferences, relationInstanceCount: 0 }
+  }
+
+  /**
+   * Deletes a relation type, converting gloss references to text.
+   *
+   * @returns the success message and the cleaned-up gloss reference count
+   * @throws {NotFoundError} when the persona, ontology, or type does not exist
+   * @throws {ForbiddenError} when delete access is denied
+   */
+  async deleteRelationType(
+    personaId: string,
+    typeId: string
+  ): Promise<{ message: string; cleanedUp: { glossReferences: number } }> {
+    const persona = await this.loadForTypeDelete(personaId)
+    const ontology = persona.ontology!
+
+    const relationTypes = asTypesWithGloss(ontology.relationTypes)
+    const targetType = relationTypes.find(t => t.id === typeId)
+    if (!targetType) {
+      throw new NotFoundError('Relation type', typeId)
+    }
+
+    const typeName = targetType.name
+    const updatedRelationTypes = relationTypes.filter(t => t.id !== typeId)
+
+    const entityTypes = asTypesWithGloss(ontology.entityTypes)
+    const roleTypes = asTypesWithGloss(ontology.roleTypes)
+    const eventTypes = asTypesWithGloss(ontology.eventTypes)
+
+    let glossReferences = 0
+    glossReferences += countTypeRefsInGlosses(entityTypes, typeId, personaId, 'relation')
+    glossReferences += countTypeRefsInGlosses(roleTypes, typeId, personaId, 'relation')
+    glossReferences += countTypeRefsInGlosses(eventTypes, typeId, personaId, 'relation')
+    glossReferences += countTypeRefsInGlosses(updatedRelationTypes, typeId, personaId, 'relation')
+
+    const cleanedEntityTypes = updateGlossesInTypes(entityTypes, typeId, personaId, 'relation', typeName)
+    const cleanedRoleTypes = updateGlossesInTypes(roleTypes, typeId, personaId, 'relation', typeName)
+    const cleanedEventTypes = updateGlossesInTypes(eventTypes, typeId, personaId, 'relation', typeName)
+    const cleanedRelationTypes = updateGlossesInTypes(updatedRelationTypes, typeId, personaId, 'relation', typeName)
+
+    await this.repository.updateOntology(personaId, {
+      entityTypes: toJson(cleanedEntityTypes),
+      roleTypes: toJson(cleanedRoleTypes),
+      eventTypes: toJson(cleanedEventTypes),
+      relationTypes: toJson(cleanedRelationTypes)
+    })
+
+    return {
+      message: `Relation type "${typeName}" deleted successfully`,
+      cleanedUp: { glossReferences }
+    }
+  }
+
+  /**
+   * Maps a database ontology row to the API response shape: database field
+   * names are renamed (`entityTypes` to `entities`, etc.), `relations` is
+   * always empty, and dates are ISO strings.
+   */
+  private mapOntologyResponse(ontology: NonNullable<PersonaWithOntology['ontology']>): OntologyResponse {
+    return {
+      id: ontology.id,
+      personaId: ontology.personaId,
+      entities: (ontology.entityTypes as unknown[]) || [],
+      roles: (ontology.roleTypes as unknown[]) || [],
+      events: (ontology.eventTypes as unknown[]) || [],
+      relationTypes: (ontology.relationTypes as unknown[]) || [],
+      relations: [],
+      createdAt: ontology.createdAt.toISOString(),
+      updatedAt: ontology.updatedAt.toISOString()
+    }
+  }
+}


### PR DESCRIPTION
## Description

**Phase 4.1 — extract the personas domain into a service + repository layer** (the proof-of-pattern for the remaining domain extractions). `server/src/routes/personas.ts` drops from 1641 lines with 44 direct `prisma.*` calls to 640 thin lines with zero. Folds in issue #11 (expose `Persona.projectId`) and fixes a pre-existing persona-test isolation flake found while running E2E. Part of the `0.5.0` cycle on `release/0.5.x`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test improvements

## Related Issues

No GitHub tracking issue. Folds in upstream `notes/fovea-issues/11` (persona project scoping — backend half). Roadmap: `notes/architecture-review.md`, Phase 4.

## Changes Made

- New `server/src/repositories/PersonaRepository.ts` (pure Prisma data access, mirroring `VideoRepository`: constructor takes `PrismaClient`, returns raw model types, no RBAC).
- New `server/src/services/persona-service.ts` (orchestration + RBAC + response mapping, mirroring `ImportHandler`: holds the request-scoped `AppAbility`/`userId`, owns the CASL `accessibleBy`/`subject`/`can` checks, the list-mode branching, the `isSystemGenerated` coercion, and the ontology type-deletion / world-state-cleanup orchestration).
- `server/src/routes/personas.ts`: routes are now thin (validate → dispatch to the service); 0 `prisma.*` calls. `PersonaRepository` is constructed once at plugin registration; a per-request `PersonaService` wraps it.
- **#11**: `PersonaSchema` and the frontend `Persona` type now expose `projectId` (it was silently stripped by the response schema before).
- **Test fix**: `testPersonaPersistent` now names its persona uniquely per test (`workerIndex` + `userId` + `testId`); previously the worker-stable name caused parallel persistence tests to accumulate same-named personas and fail a strict-mode dropdown locator.

## Testing

### Test Environment

- OS: macOS (Darwin 24.6.0); Node 22; Docker 28.4.0

### Test Cases

- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. `tsc --noEmit` + `lint` (server + frontend) pass. Full server suite **1205 pass** (incl. the personas route tests asserting `isSystemGenerated` coercion and the `worldState.findFirst({ userId, projectId: null })` cleanup); full frontend suite **1781 pass**.
2. **E2E** (e2e-mock stack, per the pre-PR gate): smoke 76/76; the regression suite is **261/0** single-worker. The full 4-project concurrent run shows only resource/worker-churn flakes (each passes in isolation/single-worker) — the documented environmental flakiness, not regressions. Verified identical failures reproduce on `release/0.5.x` without this change.
3. This PR depends on #156 (already merged) — the backend would not boot in the e2e stack before that fix.

## Screenshots/Videos

N/A — behavior-preserving backend refactor + a schema field addition.

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

## Breaking Changes

**Breaking changes:**
- None. RBAC decisions, response shapes, and behavior are unchanged; `projectId` is an additive response field.

**Migration guide:**
- N/A.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This establishes the `Repository` (data) / `Service` (orchestration + RBAC) / thin-route pattern that 4.3 (claims) and 4.4 (world) will follow.

## Reviewer Guidance

Start with `persona-service.ts` (confirm the RBAC checks match the old inline ones) and the thin `personas.ts`. The repository is mechanical. The test-fixture change just lengthens the persona name for uniqueness; worker cleanup deletes by `userId`, so it's unaffected.
