### PR TITLE
fix: resolve cross-user object names server-side on the annotations endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 ### Fixed
 
+#### Reviewers Can Resolve Cross-User Object Names
+
+- The annotations list endpoint (`GET /api/annotations/:videoId`) now returns an optional server-resolved `linkedObjectName`, and `AnnotationOverlay` uses it as a fallback badge label. World objects (entities/events/times/locations) are per-user, so a reviewer reading another annotator's object annotation previously saw a generic "Entity" badge — their own world could not resolve the other annotator's object id. The server now resolves the linked object's display name from the **owner's** world (batched: one `worldState.findMany` over the distinct owners on the page), gated implicitly by the existing `accessibleBy(read)` filter so only annotations the caller may already read are resolved and only the name is exposed. The frontend still prefers the live local object when the caller shares the world; `linkedObjectName` is the fallback when it cannot.
+
 #### Release Workflow Now Publishes GitHub Releases
 
 - `release.yml` gains a `create-release` job that, on every `v*.*.*` tag push, extracts the matching `CHANGELOG.md` section and creates or updates the GitHub Release. Previously the workflow only built and pushed Docker images, so a tag published no GitHub Release unless one was made by hand (which is how v0.4.3's Release came to be missing). The job is deliberately independent of the image build, so a Release is published even when the heavy `model-service-gpu` image hits the 90-minute job timeout.

--- a/annotation-tool/src/api/generated/openapi.ts
+++ b/annotation-tool/src/api/generated/openapi.ts
@@ -7085,6 +7085,7 @@ export interface paths {
                             frames: unknown;
                             confidence: null | number;
                             source: string;
+                            linkedObjectName?: null | string;
                             createdAt: string;
                             updatedAt: string;
                         }[];
@@ -7148,6 +7149,7 @@ export interface paths {
                             frames: unknown;
                             confidence: null | number;
                             source: string;
+                            linkedObjectName?: null | string;
                             createdAt: string;
                             updatedAt: string;
                         };
@@ -7208,6 +7210,7 @@ export interface paths {
                             frames: unknown;
                             confidence: null | number;
                             source: string;
+                            linkedObjectName?: null | string;
                             createdAt: string;
                             updatedAt: string;
                         };

--- a/annotation-tool/src/components/annotation/AnnotationOverlay.test.tsx
+++ b/annotation-tool/src/components/annotation/AnnotationOverlay.test.tsx
@@ -16,10 +16,11 @@ import { server } from '@test/setup'
  * Mock InteractiveBoundingBox to avoid complex rendering.
  */
 vi.mock('./InteractiveBoundingBox', () => ({
-  default: ({ annotation, isActive, onSelect }: any) => (
+  default: ({ annotation, linkedObject, isActive, onSelect }: any) => (
     <rect
       data-testid={`annotation-${annotation.id}`}
       data-active={isActive}
+      data-linked-name={linkedObject?.name ?? ''}
       onClick={onSelect}
       x={0}
       y={0}
@@ -525,6 +526,72 @@ describe('AnnotationOverlay', () => {
 
       // SVG should still be present
       expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('falls back to linkedObjectName when the local world lacks the linked object', async () => {
+      // Reviewer reading another annotator's object annotation: the linked
+      // entity lives in the owner's world, not the reviewer's, so the local
+      // world lookup resolves nothing. The server-resolved linkedObjectName
+      // should drive the badge name instead of a generic kind label.
+      server.use(
+        http.get('/api/world', () => {
+          // Reviewer's own world is empty (does not contain owner-entity-1).
+          return HttpResponse.json({
+            entities: [],
+            events: [],
+            times: [],
+            entityCollections: [],
+            eventCollections: [],
+            timeCollections: [],
+            relations: [],
+          })
+        }),
+        http.get('/api/annotations/:videoId', () => {
+          return HttpResponse.json([
+            {
+              id: 'ann-cross-user',
+              videoId: 'test-video',
+              personaId: null,
+              type: 'object',
+              label: 'owner-entity-1',
+              linkType: 'entity',
+              linkedObjectName: 'Owner Entity',
+              frames: {
+                boxes: [{ x: 100, y: 100, width: 200, height: 200, frameNumber: 150, isKeyframe: true }],
+                interpolationSegments: [],
+                visibilityRanges: [{ startFrame: 150, endFrame: 150, visible: true }],
+                totalFrames: 1,
+                keyframeCount: 1,
+                interpolatedFrameCount: 0,
+              },
+              confidence: null,
+              source: 'manual',
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ])
+        })
+      )
+
+      const Wrapper = createWrapper()
+
+      render(
+        <AnnotationOverlay
+          videoElement={mockVideoElement}
+          currentTime={currentTime}
+          videoWidth={videoWidth}
+          videoHeight={videoHeight}
+          detectionResults={null}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        const annotationElement = screen.getByTestId('annotation-ann-cross-user')
+        // The badge name comes from the server-resolved linkedObjectName
+        // because the local world has no matching entity.
+        expect(annotationElement).toHaveAttribute('data-linked-name', 'Owner Entity')
+      })
     })
 
     it('filters annotations by selected persona in type mode', async () => {

--- a/annotation-tool/src/components/annotation/AnnotationOverlay.tsx
+++ b/annotation-tool/src/components/annotation/AnnotationOverlay.tsx
@@ -20,8 +20,13 @@ import type { Annotation, Entity, Event, EntityCollection, EventCollection } fro
  * @description Annotation with resolved linked object information for display.
  */
 type EnrichedAnnotation = Annotation & {
-  /** Resolved linked object (entity, event, location, or collection) */
-  linkedObject?: Entity | Event | EntityCollection | EventCollection
+  /**
+   * Resolved linked object for badge display. Normally a full world object
+   * (entity, event, location, or collection) from the caller's own world. For
+   * cross-user reads where the caller does not share the owner's world, this
+   * is a name-only stand-in built from the server-resolved linkedObjectName.
+   */
+  linkedObject?: Entity | Event | EntityCollection | EventCollection | { name: string }
   /** Type of the linked object */
   linkedType?: 'entity' | 'event' | 'location' | 'entity-collection' | 'event-collection'
   /** Resolved type name from ontology (for type annotations) */
@@ -212,6 +217,15 @@ export default function AnnotationOverlay({
             enriched.linkedObject = collection
             enriched.linkedType = ann.linkedCollectionType === 'entity' ? 'entity-collection' : 'event-collection'
           }
+        }
+
+        // Fallback for cross-user reads: when the caller does not share the
+        // owner's world, the local map lookup above resolves nothing. Use the
+        // server-resolved linkedObjectName so the badge still shows the object
+        // name instead of a generic kind label. The live local object stays
+        // the primary source (preferred when the caller does share the world).
+        if (!enriched.linkedObject && ann.linkedObjectName) {
+          enriched.linkedObject = { name: ann.linkedObjectName }
         }
       }
 

--- a/annotation-tool/src/models/annotation.ts
+++ b/annotation-tool/src/models/annotation.ts
@@ -24,6 +24,14 @@ interface BaseAnnotation {
 
   /** Confidence score for this annotation (0-1) */
   confidence?: number
+  /**
+   * Display name of the linked world object, resolved server-side from the
+   * annotation owner's world. Lets a reviewer reading another annotator's
+   * object annotation show the object's name even though the object lives in
+   * the owner's private world (not the reviewer's). Used only as a fallback
+   * when the local world lookup cannot resolve the object.
+   */
+  linkedObjectName?: string | null
   /** User notes attached to this annotation */
   notes?: string
   /** Additional metadata */

--- a/annotation-tool/src/services/api.ts
+++ b/annotation-tool/src/services/api.ts
@@ -40,6 +40,10 @@ export interface BackendAnnotation {
   frames: BoundingBoxSequence
   confidence: number | null
   source: string
+  /// Display name of the linked world object, resolved server-side from the
+  /// annotation owner's world. Present only on object annotations the server
+  /// could resolve; absent or null otherwise.
+  linkedObjectName?: string | null
   createdAt: string
   updatedAt: string
 }
@@ -58,6 +62,10 @@ export function transformBackendToFrontend(backendAnnotation: BackendAnnotation)
     videoId: backendAnnotation.videoId,
     boundingBoxSequence: backendAnnotation.frames,
     confidence: backendAnnotation.confidence ?? undefined,
+    // Carry the server-resolved linked object name through so the overlay can
+    // fall back to it when the local world lacks the linked object (a reviewer
+    // reading another annotator's annotation).
+    linkedObjectName: backendAnnotation.linkedObjectName ?? null,
     createdAt: backendAnnotation.createdAt,
     updatedAt: backendAnnotation.updatedAt,
     // Forward the server's source flag through the metadata bag so

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -86,6 +86,10 @@ The 0.5.0 cycle delivers the architecture-modularization roadmap (`notes/archite
 
 ### Fixed
 
+#### Reviewers Can Resolve Cross-User Object Names
+
+- The annotations list endpoint (`GET /api/annotations/:videoId`) now returns an optional server-resolved `linkedObjectName`, and `AnnotationOverlay` uses it as a fallback badge label. World objects (entities/events/times/locations) are per-user, so a reviewer reading another annotator's object annotation previously saw a generic "Entity" badge — their own world could not resolve the other annotator's object id. The server now resolves the linked object's display name from the **owner's** world (batched: one `worldState.findMany` over the distinct owners on the page), gated implicitly by the existing `accessibleBy(read)` filter so only annotations the caller may already read are resolved and only the name is exposed. The frontend still prefers the live local object when the caller shares the world; `linkedObjectName` is the fallback when it cannot.
+
 #### Release Workflow Now Publishes GitHub Releases
 
 - `release.yml` gains a `create-release` job that, on every `v*.*.*` tag push, extracts the matching `CHANGELOG.md` section and creates or updates the GitHub Release. Previously the workflow only built and pushed Docker images, so a tag published no GitHub Release unless one was made by hand (which is how v0.4.3's Release came to be missing). The job is deliberately independent of the image build, so a Release is published even when the heavy `model-service-gpu` image hits the 90-minute job timeout.

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -16280,6 +16280,16 @@
                       "source": {
                         "type": "string"
                       },
+                      "linkedObjectName": {
+                        "anyOf": [
+                          {
+                            "type": "null"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
                       "createdAt": {
                         "type": "string"
                       },
@@ -16443,6 +16453,16 @@
                     "source": {
                       "type": "string"
                     },
+                    "linkedObjectName": {
+                      "anyOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -16595,6 +16615,16 @@
                     },
                     "source": {
                       "type": "string"
+                    },
+                    "linkedObjectName": {
+                      "anyOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
                     "createdAt": {
                       "type": "string"

--- a/server/src/routes/annotations.ts
+++ b/server/src/routes/annotations.ts
@@ -24,9 +24,68 @@ const AnnotationResponseSchema = Type.Object({
   frames: Type.Unknown(),
   confidence: Type.Union([Type.Null(), Type.Number()]),
   source: Type.String(),
+  /// Display name of the linked world object, resolved server-side from the
+  /// annotation owner's WorldState. Lets a reviewer reading another
+  /// annotator's object annotation see the object's name even though the
+  /// object lives in the owner's private world (not the reviewer's). Absent
+  /// for type annotations and null when the object cannot be resolved.
+  linkedObjectName: Type.Optional(Type.Union([Type.Null(), Type.String()])),
   createdAt: Type.String(),
   updatedAt: Type.String()
 })
+
+/**
+ * Kinds of world object an object annotation may link to via its `label`.
+ */
+const RESOLVABLE_LINK_TYPES = new Set(['entity', 'event', 'time', 'location'])
+
+/**
+ * A world object as stored in a WorldState JSON array. Only the fields the
+ * name resolver needs are typed; arrays hold richer shapes than this.
+ */
+interface WorldObjectRecord {
+  id?: unknown
+  name?: unknown
+  label?: unknown
+}
+
+/**
+ * Builds an id -> display-name index over a single owner's WorldState.
+ *
+ * `linkType` determines which JSON array the object lives in:
+ * - entity, location -> `entities` (locations are entities carrying a
+ *   `locationType` field, so they share the entities array)
+ * - event -> `events`
+ * - time -> `times`
+ *
+ * The display name is the object's `name`; times carry a `label` instead of a
+ * `name`, so `label` is used as a fallback. Objects missing both are skipped.
+ *
+ * @param worldState - the owner's WorldState row (entities/events/times JSON)
+ * @returns map from world-object id to its display name
+ */
+function indexWorldObjectNames(worldState: {
+  entities: unknown
+  events: unknown
+  times: unknown
+}): Map<string, string> {
+  const index = new Map<string, string>()
+  const arrays: unknown[] = [worldState.entities, worldState.events, worldState.times]
+  for (const arr of arrays) {
+    if (!Array.isArray(arr)) continue
+    for (const raw of arr) {
+      const obj = raw as WorldObjectRecord
+      if (typeof obj?.id !== 'string') continue
+      const name = typeof obj.name === 'string'
+        ? obj.name
+        : typeof obj.label === 'string'
+          ? obj.label
+          : null
+      if (name !== null) index.set(obj.id, name)
+    }
+  }
+  return index
+}
 
 /**
  * Fastify plugin for annotation-related routes.
@@ -57,6 +116,7 @@ const annotationsRoute: FastifyPluginAsync = async (fastify) => {
   }, async (request, reply) => {
     const { videoId } = request.params as { videoId: string }
     if (!request.ability) throw new ForbiddenError('No abilities defined')
+    const userId = request.user!.id
 
     // FOVEA_DEMO_MODE override: demo deployments seed system-
     // generated annotations on the curated tour videos that are
@@ -89,6 +149,46 @@ const annotationsRoute: FastifyPluginAsync = async (fastify) => {
       orderBy: { createdAt: 'asc' },
     })
 
+    // Resolve linkedObjectName for object annotations from each annotation
+    // owner's WorldState. World objects (entities/events/times/locations) are
+    // per-user JSON private to their owner, so a reviewer reading another
+    // annotator's object annotation cannot resolve the linked object's name
+    // from their own world. This privileged read exposes only the object's
+    // name and only for annotations the caller already passed the CASL read
+    // filter above. Batch the owners into one query, then index per owner.
+    const ownerIds = new Set<string>()
+    for (const a of annotations) {
+      if (a.linkType && RESOLVABLE_LINK_TYPES.has(a.linkType) && a.label) {
+        ownerIds.add(a.createdByUserId ?? userId)
+      }
+    }
+
+    const nameIndexByOwner = new Map<string, Map<string, string>>()
+    if (ownerIds.size > 0) {
+      const worldStates = await fastify.prisma.worldState.findMany({
+        where: { userId: { in: [...ownerIds] }, projectId: null },
+        select: { userId: true, entities: true, events: true, times: true },
+      })
+      for (const ws of worldStates) {
+        nameIndexByOwner.set(ws.userId, indexWorldObjectNames(ws))
+      }
+    }
+
+    /**
+     * Resolves the display name of an annotation's linked world object.
+     *
+     * @param a - the annotation row
+     * @returns the object's name, or null when it is a type annotation or the
+     *   object cannot be found in the owner's world
+     */
+    const resolveLinkedObjectName = (a: typeof annotations[number]): string | null => {
+      if (!a.linkType || !RESOLVABLE_LINK_TYPES.has(a.linkType) || !a.label) {
+        return null
+      }
+      const ownerId = a.createdByUserId ?? userId
+      return nameIndexByOwner.get(ownerId)?.get(a.label) ?? null
+    }
+
     return reply.send(annotations.map(a => ({
       id: a.id,
       videoId: a.videoId,
@@ -99,6 +199,7 @@ const annotationsRoute: FastifyPluginAsync = async (fastify) => {
       frames: a.frames,
       confidence: a.confidence,
       source: a.source,
+      linkedObjectName: resolveLinkedObjectName(a),
       createdAt: a.createdAt.toISOString(),
       updatedAt: a.updatedAt.toISOString()
     })))

--- a/server/test/routes/annotations.test.ts
+++ b/server/test/routes/annotations.test.ts
@@ -3,7 +3,7 @@ import { buildApp } from '../../src/app.js'
 import { hashPassword } from '../../src/lib/password.js'
 import { seedBaselinePermissions } from '../helpers/rbac-test-setup.js'
 import { FastifyInstance } from 'fastify'
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 
 /**
  * Integration tests for the Annotations API.
@@ -31,6 +31,7 @@ describe('Annotations API', () => {
     await prisma.annotation.deleteMany()
     await prisma.videoSummary.deleteMany()
     await prisma.ontology.deleteMany()
+    await prisma.worldState.deleteMany()
     await prisma.persona.deleteMany()
     await prisma.video.deleteMany()
     await prisma.session.deleteMany()
@@ -319,6 +320,155 @@ describe('Annotations API', () => {
       })
 
       expect(response.statusCode).toBe(404)
+    })
+  })
+
+  describe('GET /api/annotations/:videoId linkedObjectName', () => {
+    /**
+     * A reviewer reading another annotator's object annotation should see the
+     * linked world object's name resolved from the annotation owner's world,
+     * even though that world is private to its owner.
+     */
+    it('resolves linkedObjectName from the annotation owner world for a cross-user reviewer', async () => {
+      // Owner (user A) authors the world objects and the annotations.
+      const ownerHash = await hashPassword('ownerpass123')
+      const owner = await prisma.user.create({
+        data: {
+          username: 'annotation-owner',
+          email: 'owner@example.com',
+          passwordHash: ownerHash,
+          displayName: 'Annotation Owner',
+          isAdmin: false,
+          systemRole: 'user',
+        }
+      })
+
+      // Owner's private world: an entity, an event, and a location entity.
+      await prisma.worldState.create({
+        data: {
+          userId: owner.id,
+          projectId: null,
+          entities: [
+            { id: 'entity-1', name: 'Red Car' },
+            { id: 'location-1', name: 'Town Square', locationType: 'point' },
+          ] as unknown as Prisma.InputJsonValue,
+          events: [{ id: 'event-1', name: 'Collision' }] as unknown as Prisma.InputJsonValue,
+          times: [] as unknown as Prisma.InputJsonValue,
+        }
+      })
+
+      // Owner's annotations: an entity-linked, an event-linked, a location-
+      // linked object annotation, plus a type annotation and an object
+      // annotation whose label is absent from the owner's world.
+      await prisma.annotation.create({
+        data: {
+          videoId: testVideoId,
+          personaId: null,
+          userId: owner.id,
+          createdByUserId: owner.id,
+          type: 'object',
+          label: 'entity-1',
+          linkType: 'entity',
+          frames: { boxes: [] }
+        }
+      })
+      await prisma.annotation.create({
+        data: {
+          videoId: testVideoId,
+          personaId: null,
+          userId: owner.id,
+          createdByUserId: owner.id,
+          type: 'object',
+          label: 'event-1',
+          linkType: 'event',
+          frames: { boxes: [] }
+        }
+      })
+      await prisma.annotation.create({
+        data: {
+          videoId: testVideoId,
+          personaId: null,
+          userId: owner.id,
+          createdByUserId: owner.id,
+          type: 'object',
+          label: 'location-1',
+          linkType: 'location',
+          frames: { boxes: [] }
+        }
+      })
+      await prisma.annotation.create({
+        data: {
+          videoId: testVideoId,
+          personaId: testPersonaId,
+          userId: owner.id,
+          createdByUserId: owner.id,
+          type: 'type',
+          label: 'entity-type-1',
+          frames: { boxes: [] }
+        }
+      })
+      await prisma.annotation.create({
+        data: {
+          videoId: testVideoId,
+          personaId: null,
+          userId: owner.id,
+          createdByUserId: owner.id,
+          type: 'object',
+          label: 'missing-object',
+          linkType: 'entity',
+          frames: { boxes: [] }
+        }
+      })
+
+      // Reviewer (user B) is a system admin, so the CASL read filter grants
+      // read on the owner's annotations. The reviewer has no world of their
+      // own, so any name they see must come from the owner's world.
+      const reviewerHash = await hashPassword('reviewerpass123')
+      const reviewer = await prisma.user.create({
+        data: {
+          username: 'annotation-reviewer',
+          email: 'reviewer@example.com',
+          passwordHash: reviewerHash,
+          displayName: 'Annotation Reviewer',
+          isAdmin: true,
+          systemRole: 'system_admin',
+        }
+      })
+      const reviewerSession = await prisma.session.create({
+        data: {
+          userId: reviewer.id,
+          token: `test-session-${reviewer.id}`,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        }
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/annotations/${testVideoId}`,
+        cookies: { session_token: reviewerSession.token }
+      })
+
+      expect(response.statusCode).toBe(200)
+      const annotations = response.json() as Array<{
+        type: string
+        label: string
+        linkType: string | null
+        linkedObjectName: string | null
+      }>
+
+      const byLabel = (label: string) => annotations.find(a => a.label === label)!
+
+      // Entity, event, and location names resolve from the owner's world.
+      expect(byLabel('entity-1').linkedObjectName).toBe('Red Car')
+      expect(byLabel('event-1').linkedObjectName).toBe('Collision')
+      expect(byLabel('location-1').linkedObjectName).toBe('Town Square')
+
+      // Type annotations carry no linked object name.
+      expect(byLabel('entity-type-1').linkedObjectName).toBeNull()
+
+      // Object annotations whose label is absent from the owner world resolve
+      // to null rather than a stale or fabricated name.
+      expect(byLabel('missing-object').linkedObjectName).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Description

**Phase 4.6c — fold issue #04 (reviewers can't resolve cross-user object names).** World objects (entities/events/times/locations) are per-user, so a reviewer reading another annotator's object annotation saw a generic "Entity" badge — their own world couldn't resolve the other annotator's object id. This adds an optional, server-resolved `linkedObjectName` to the annotations list endpoint (resolved from the **owner's** world, gated by the existing `accessibleBy(read)` filter) and uses it as a fallback badge label in `AnnotationOverlay`. Part of the `0.5.0` cycle on `release/0.5.x` (no version bump).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test improvements

## Related Issues

No GitHub tracking issue. Folds in upstream `notes/fovea-issues/04` (reviewers can't resolve cross-user object names). Roadmap: `notes/architecture-review.md`, Phase 4.6c.

## Changes Made

- **Backend** `server/src/routes/annotations.ts`:
  - Added `linkedObjectName: Type.Optional(Type.Union([Type.Null(), Type.String()]))` to `AnnotationResponseSchema`.
  - In the list handler (which already applies `accessibleBy(request.ability, 'read').Annotation`), resolves the linked object's name for object annotations. An object annotation stores the world-object id in `label` and the kind in `linkType` (`entity`/`event`/`time`/`location`); the owner is `createdByUserId ?? caller`. The handler collects the distinct owners across the page's object annotations and issues **one** `worldState.findMany({ where: { userId: { in: owners }, projectId: null }, select: { entities, events, times } })`, builds an `owner → (objectId → name)` index, and maps each annotation. Locations resolve from `entities` (a `Location` is an `Entity` with a `locationType`; there is no separate `locations` array); `Time` objects use `label` (they carry no `name`). Unresolvable / type annotations get `null`.
  - This is a deliberate privileged read (not CASL-scoped to the caller's own world) — it is safe because only annotations already passing `accessibleBy(read)` reach the resolver, and only the object's *name* is surfaced.
- **Contract regen**: `AnnotationResponseSchema` changed, so `server/openapi.json` and the frontend-generated `annotation-tool/src/api/generated/openapi.ts` are regenerated and committed (deterministic) — the `contract-drift` gate stays green.
- **Frontend**: `linkedObjectName?: string | null` on `BaseAnnotation` (`models/annotation.ts`), flowed through `services/api.ts` (`transformBackendToFrontend`); `AnnotationOverlay.tsx` falls back to it for the badge label when the local world lookup misses. The live local object is still preferred when the caller shares the world.

## Testing

### Test Cases

- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Backend: `server/test/routes/annotations.test.ts` gains a cross-user case — user A creates a world entity + an object annotation linking it; reviewer B (read access, no shared world) reads the list and gets `linkedObjectName` resolved from A's world; type annotations and missing objects resolve to `null`. Full server suite **1236 pass**; `tsc`/lint clean.
2. Frontend: `AnnotationOverlay.test.tsx` gains a fallback case (object absent from the local world → badge uses `linkedObjectName`). `tsc`/lint clean.
3. `server/openapi.json` + the generated frontend types regenerate byte-identically (deterministic).
4. **E2E** (e2e-mock stack rebuilt on this branch, scoped to the affected annotation-rendering specs — `object-annotation-persona`, `bounding-box`, `annotation-persistence`, single-worker): **10 passed, 0 failed**, 2 flaky (bounding-box video-load + annotation auto-save — the documented resource/churn flakes, both passed on retry). The object-annotation rendering and the list endpoint's new resolution path work end-to-end; same-user badge rendering is unchanged.

## Screenshots/Videos

N/A — additive badge-label fallback.

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact (one additional batched `worldState.findMany` per annotations-list request, only when object annotations are present)

## Breaking Changes

**Breaking changes:**
- None. `linkedObjectName` is an additive optional response field; same-world rendering is unchanged (the fallback only triggers when the local world cannot resolve the object).

**Migration guide:**
- N/A.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The longer-term alternative (project-level shareable world objects) is a larger design change that conflicts with the per-user world model; this server-side name resolution is the targeted fix the issue recommends.

## Reviewer Guidance

The core is the batched resolution in `annotations.ts` (`indexWorldObjectNames` + the list handler) — confirm it loads the owner's world (not the caller's) and only exposes the name. The frontend change is a fallback only. `openapi.json` / generated types are outputs.
