### PR TITLE
release: bump to 0.5.3 and record the claim-card fix in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-06-24
+
+The 0.5.3 patch fixes a claims-workspace interaction bug ([#177](https://github.com/parafovea/fovea/pull/177)). No API shapes change and nothing is breaking.
+
+### Fixed
+
+#### Clicking a Claim Card No Longer Switches to the Summary Tab
+
+- In the video summary editor's Claims tab, clicking a claim card switched the interface back to the Summary tab, which is not what clicking a card should do. A card now selects in place: it is marked selected on the Claims tab and records its source spans so the Summary tab highlights the claim's provenance only if the user chooses to switch there. The card's selected styling, previously bound to a state value that was never set, is now driven by the selected-claim state (`annotation-tool/src/components/video/VideoSummaryEditor.tsx`, `annotation-tool/src/components/claims/ClaimsViewer.tsx`).
+
 ## [0.5.2] - 2026-06-22
 
 The 0.5.2 patch fixes a Safari-only failure ([#143](https://github.com/parafovea/fovea/issues/143)) where a video in the annotation workspace blacked out the moment it was paused and jumped position on resume, while Chrome and Firefox played it back correctly. The cause was twofold: the video stream endpoint mishandled the byte-range requests Safari issues but Chrome does not, and WebKit dropped the paused video frame from its compositor. No API shapes change and nothing is breaking.

--- a/annotation-tool/package.json
+++ b/annotation-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fovea/annotation-tool",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -11,6 +11,16 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-06-24
+
+The 0.5.3 patch fixes a claims-workspace interaction bug ([#177](https://github.com/parafovea/fovea/pull/177)). No API shapes change and nothing is breaking.
+
+### Fixed
+
+#### Clicking a Claim Card No Longer Switches to the Summary Tab
+
+- In the video summary editor's Claims tab, clicking a claim card switched the interface back to the Summary tab, which is not what clicking a card should do. A card now selects in place: it is marked selected on the Claims tab and records its source spans so the Summary tab highlights the claim's provenance only if the user chooses to switch there. The card's selected styling, previously bound to a state value that was never set, is now driven by the selected-claim state (`annotation-tool/src/components/video/VideoSummaryEditor.tsx`, `annotation-tool/src/components/claims/ClaimsViewer.tsx`).
+
 ## [0.5.2] - 2026-06-22
 
 The 0.5.2 patch fixes a Safari-only failure ([#143](https://github.com/parafovea/fovea/issues/143)) where a video in the annotation workspace blacked out the moment it was paused and jumped position on resume, while Chrome and Firefox played it back correctly. The cause was twofold: the video stream endpoint mishandled the byte-range requests Safari issues but Chrome does not, and WebKit dropped the paused video frame from its compositor. No API shapes change and nothing is breaking.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/model-service/package.json
+++ b/model-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fovea-model-service",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "AI model inference service for video annotation",
   "scripts": {
     "dev": "source venv/bin/activate && uvicorn src.main:app --reload --host 0.0.0.0 --port 8000",

--- a/model-service/pyproject.toml
+++ b/model-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fovea-model-service"
-version = "0.5.2"
+version = "0.5.3"
 description = "Model service for fovea video annotation tool"
 requires-python = ">=3.12"
 dependencies = [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fovea",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "FOVEA - Flexible Ontology Visual Event Analyzer",
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fovea/server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description

Opens the 0.5.3 patch: bumps every workspace package to `0.5.3` and records the claim-card selection fix (PR #177, already merged to `release/0.5.x`) in both changelogs. Version/changelog only — no code change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Build/infrastructure changes

## Related Issues

Records PR #177 (claim-card selection fix). No standalone tracked issue.

## Changes Made

- Bumped `package.json`, `annotation-tool/package.json`, `server/package.json`, `model-service/package.json`, `docs/package.json`, and `model-service/pyproject.toml` from `0.5.2` to `0.5.3`.
- Added a `## [0.5.3]` section to `CHANGELOG.md` and `docs/docs/project/changelog.md` describing the claim-card fix.

## Testing

### Test Environment

- OS: macOS (Darwin 24.6.0)
- Browser (if applicable): n/a
- Node version: 22
- Python version (if applicable): n/a

### Test Cases

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

No code changed; the claim-card fix itself was verified in PR #177 (frontend unit suite green, E2E proven red->green). Changelog Markdown is backtick-safe for the Docusaurus MDX build.

### How to Test

1. Confirm all six version declarations read `0.5.3`.
2. Confirm the `## [0.5.3]` changelog section renders.

## Screenshots/Videos

n/a

## Documentation

- [ ] Code comments updated
- [ ] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: version/changelog only.

## Breaking Changes

**Breaking changes:**
- None.

**Migration guide:**
- None required.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Targets `release/0.5.x`. After merge this is ready to promote to `main` and tag `v0.5.3` (same flow as v0.5.2) whenever you want to cut the release.

## Reviewer Guidance

Trivial release-prep diff: six version strings plus one changelog section mirrored into both changelog files.
