### PR TITLE
fix: backend correctness & security hardening (v0.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2026-06-30
+
+The 0.5.6 patch is the first of three audit-driven hardening releases — the backend slice — fixing a batch of authorization, data-integrity, idempotency, and concurrency defects surfaced by a code audit ([#188](https://github.com/parafovea/fovea/pull/188)). Nothing is breaking; the API additively gains `409` conflict responses on duplicate creates and the resource-fork now produces correctly-scoped resources.
+
+### Fixed
+
+#### Authorization and Access Control
+
+- The Bull Board queue dashboard (`/admin/queues`) was mounted with no authentication, exposing queued job payloads and Bull Board's mutating actions to any client that could reach the server. It is now gated behind an admin `onRequest` hook (`server/src/app.ts`).
+- A password change did not revoke the user's existing sessions, so a stolen or shared token survived a reset. Both the self-service profile update and the admin user update now revoke all of the affected user's sessions (the self-update re-issues a fresh session so the acting client stays logged in) (`server/src/routes/users.ts`).
+- The ontology importer overwrote any persona's ontology with no ownership check, letting any authenticated user clobber another user's ontology by uploading a line targeting their persona. The importer now enforces the same instance-level CASL update check as the rest of the app (`server/src/services/import/entity-importers.ts`).
+- The claim-relation privacy filter on `getRelations` was a no-op (an `OR` over either endpoint, the known one of which is always readable), leaking the existence and metadata of relations to claims the caller cannot read. Each query now requires the opposite endpoint to be accessible (`server/src/services/claim-service.ts`).
+- The corpus-manifest sync changed group memberships/roles and project ownership without invalidating the in-memory CASL ability cache, so a downgrade lingered until restart. The sync now clears the ability cache when it reconciles memberships or ownership (`server/src/services/videoSync.ts`).
+- The last `project_owner` could be demoted (via change-role) or stranded (via admin user-deletion), leaving a project with no owner. Both paths now enforce the last-owner invariant (`server/src/services/project-service.ts`, `server/src/routes/users.ts`).
+- Per-IP rate limiting trusted a fully spoofable `X-Forwarded-For` because `trustProxy` was `true`; it is now configurable via `TRUST_PROXY` and defaults to trusting a single proxy hop (`server/src/app.ts`, `server/src/config.ts`).
+- The demo seed fixture loader interpolated an unconstrained `tourId` into a filename (path traversal); `tourId` is now constrained to a strict charset at the route boundary (`server/src/demo/seed.ts`).
+
+#### Idempotency and Conflict Handling
+
+- Creating a resource share, a claim relation, a user, or a group is now idempotent / conflict-safe: duplicate shares and claim relations no longer accumulate (a re-issue reuses the existing row), and a duplicate user email/username or group slug returns `409 Conflict` instead of a `500`. New uniqueness constraints back these (a `ClaimRelation` triple unique and partial unique indexes on `ResourceShare` and personal `WorldState`); a migration dedupes any pre-existing duplicates before adding them (`server/src/routes/{sharing,users,groups,auth}.ts`, `server/src/services/{claim-service,project-service}.ts`, `server/prisma/migrations`).
+- A user could end up with two personal world-state rows (the compound unique did not constrain a NULL `projectId`); the personal get-or-create/update paths are now race-safe and merge on conflict, backed by a partial unique index (`server/src/services/world-state-service.ts`).
+
+#### Concurrency — Lost Updates
+
+- Concurrent edits to a persona's ontology, a project's world state, or an import running alongside a UI edit silently overwrote each other (whole-blob replace, no guard). These writes now merge each array by id under optimistic concurrency, the same pattern that protects personal world-state writes (`server/src/services/{persona-service,project-service}.ts`, `server/src/repositories/{PersonaRepository,ProjectRepository}.ts`, `server/src/routes/ontology.ts`, `server/src/services/import/entity-importers.ts`).
+
+#### World-Object Deletion Integrity
+
+- Deleting a world entity/event/time wrote the world state and cleaned up dependent ontology gloss references in two un-transacted writes, orphaning glosses on a partial failure, and bypassed the optimistic-concurrency guard so a concurrent addition could be clobbered. Each deletion now runs the guarded world-state write and all gloss cleanups in a single transaction (`server/src/services/world-state-service.ts`).
+- The world-object deletion preview always reported `annotationCount: 0`; it now counts the object annotations that reference the object.
+
+### Added
+
+#### Deep-Fork of Shared Resources
+
+- Forking a shared summary always returned a `500` (it collided on the source's `(videoId, personaId)`), and forked claims/annotations were orphaned or lost their object link. Forking now deep-copies into the forker's own scope: the source persona is forked, the summary/claim is re-pointed at the forked persona/summary, `claimsJson` is rebuilt, and annotation `linkType` is preserved (`server/src/routes/sharing.ts`).
+
+#### Conflict Responses
+
+- The user, group, and project create/update endpoints document and return `409 Conflict` on a duplicate, reflected in the OpenAPI contract and generated client types.
+
 ## [0.5.5] - 2026-06-29
 
 The 0.5.5 patch is an audit-driven hardening release ([#186](https://github.com/parafovea/fovea/pull/186)). It closes two higher-severity defects — a former group member kept the group's permissions until the server restarted, and concurrent edits to the world graph silently overwrote one another — together with a set of data-scope, idempotency, and cache-staleness gaps. Nothing is breaking; the API additively gains explicit DELETE endpoints for world collections and relations, an optional client-supplied `id` on claim creation, and a `409` on a duplicate video assignment.

--- a/annotation-tool/package.json
+++ b/annotation-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fovea/annotation-tool",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/annotation-tool/src/api/generated/openapi.ts
+++ b/annotation-tool/src/api/generated/openapi.ts
@@ -285,6 +285,17 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         delete?: never;
@@ -771,6 +782,22 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description Machine-readable error code */
+                            error: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error context */
+                            details?: unknown;
+                        };
+                    };
+                };
             };
         };
         post?: never;
@@ -816,6 +843,22 @@ export interface paths {
                     content: {
                         "application/json": {
                             error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description Machine-readable error code */
+                            error: string;
+                            /** @description Human-readable error message */
+                            message: string;
+                            /** @description Additional error context */
+                            details?: unknown;
                         };
                     };
                 };

--- a/docs/docs/project/changelog.md
+++ b/docs/docs/project/changelog.md
@@ -11,6 +11,47 @@ All notable changes to the Fovea project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2026-06-30
+
+The 0.5.6 patch is the first of three audit-driven hardening releases — the backend slice — fixing a batch of authorization, data-integrity, idempotency, and concurrency defects surfaced by a code audit ([#188](https://github.com/parafovea/fovea/pull/188)). Nothing is breaking; the API additively gains `409` conflict responses on duplicate creates and the resource-fork now produces correctly-scoped resources.
+
+### Fixed
+
+#### Authorization and Access Control
+
+- The Bull Board queue dashboard (`/admin/queues`) was mounted with no authentication, exposing queued job payloads and Bull Board's mutating actions to any client that could reach the server. It is now gated behind an admin `onRequest` hook (`server/src/app.ts`).
+- A password change did not revoke the user's existing sessions, so a stolen or shared token survived a reset. Both the self-service profile update and the admin user update now revoke all of the affected user's sessions (the self-update re-issues a fresh session so the acting client stays logged in) (`server/src/routes/users.ts`).
+- The ontology importer overwrote any persona's ontology with no ownership check, letting any authenticated user clobber another user's ontology by uploading a line targeting their persona. The importer now enforces the same instance-level CASL update check as the rest of the app (`server/src/services/import/entity-importers.ts`).
+- The claim-relation privacy filter on `getRelations` was a no-op (an `OR` over either endpoint, the known one of which is always readable), leaking the existence and metadata of relations to claims the caller cannot read. Each query now requires the opposite endpoint to be accessible (`server/src/services/claim-service.ts`).
+- The corpus-manifest sync changed group memberships/roles and project ownership without invalidating the in-memory CASL ability cache, so a downgrade lingered until restart. The sync now clears the ability cache when it reconciles memberships or ownership (`server/src/services/videoSync.ts`).
+- The last `project_owner` could be demoted (via change-role) or stranded (via admin user-deletion), leaving a project with no owner. Both paths now enforce the last-owner invariant (`server/src/services/project-service.ts`, `server/src/routes/users.ts`).
+- Per-IP rate limiting trusted a fully spoofable `X-Forwarded-For` because `trustProxy` was `true`; it is now configurable via `TRUST_PROXY` and defaults to trusting a single proxy hop (`server/src/app.ts`, `server/src/config.ts`).
+- The demo seed fixture loader interpolated an unconstrained `tourId` into a filename (path traversal); `tourId` is now constrained to a strict charset at the route boundary (`server/src/demo/seed.ts`).
+
+#### Idempotency and Conflict Handling
+
+- Creating a resource share, a claim relation, a user, or a group is now idempotent / conflict-safe: duplicate shares and claim relations no longer accumulate (a re-issue reuses the existing row), and a duplicate user email/username or group slug returns `409 Conflict` instead of a `500`. New uniqueness constraints back these (a `ClaimRelation` triple unique and partial unique indexes on `ResourceShare` and personal `WorldState`); a migration dedupes any pre-existing duplicates before adding them (`server/src/routes/{sharing,users,groups,auth}.ts`, `server/src/services/{claim-service,project-service}.ts`, `server/prisma/migrations`).
+- A user could end up with two personal world-state rows (the compound unique did not constrain a NULL `projectId`); the personal get-or-create/update paths are now race-safe and merge on conflict, backed by a partial unique index (`server/src/services/world-state-service.ts`).
+
+#### Concurrency — Lost Updates
+
+- Concurrent edits to a persona's ontology, a project's world state, or an import running alongside a UI edit silently overwrote each other (whole-blob replace, no guard). These writes now merge each array by id under optimistic concurrency, the same pattern that protects personal world-state writes (`server/src/services/{persona-service,project-service}.ts`, `server/src/repositories/{PersonaRepository,ProjectRepository}.ts`, `server/src/routes/ontology.ts`, `server/src/services/import/entity-importers.ts`).
+
+#### World-Object Deletion Integrity
+
+- Deleting a world entity/event/time wrote the world state and cleaned up dependent ontology gloss references in two un-transacted writes, orphaning glosses on a partial failure, and bypassed the optimistic-concurrency guard so a concurrent addition could be clobbered. Each deletion now runs the guarded world-state write and all gloss cleanups in a single transaction (`server/src/services/world-state-service.ts`).
+- The world-object deletion preview always reported `annotationCount: 0`; it now counts the object annotations that reference the object.
+
+### Added
+
+#### Deep-Fork of Shared Resources
+
+- Forking a shared summary always returned a `500` (it collided on the source's `(videoId, personaId)`), and forked claims/annotations were orphaned or lost their object link. Forking now deep-copies into the forker's own scope: the source persona is forked, the summary/claim is re-pointed at the forked persona/summary, `claimsJson` is rebuilt, and annotation `linkType` is preserved (`server/src/routes/sharing.ts`).
+
+#### Conflict Responses
+
+- The user, group, and project create/update endpoints document and return `409 Conflict` on a duplicate, reflected in the OpenAPI contract and generated client types.
+
 ## [0.5.5] - 2026-06-29
 
 The 0.5.5 patch is an audit-driven hardening release ([#186](https://github.com/parafovea/fovea/pull/186)). It closes two higher-severity defects — a former group member kept the group's permissions until the server restarted, and concurrent edits to the world graph silently overwrote one another — together with a set of data-scope, idempotency, and cache-staleness gaps. Nothing is breaking; the API additively gains explicit DELETE endpoints for world collections and relations, an optional client-supplied `id` on claim creation, and a `409` on a duplicate video assignment.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/model-service/package.json
+++ b/model-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fovea-model-service",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "AI model inference service for video annotation",
   "scripts": {
     "dev": "source venv/bin/activate && uvicorn src.main:app --reload --host 0.0.0.0 --port 8000",

--- a/model-service/pyproject.toml
+++ b/model-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fovea-model-service"
-version = "0.5.5"
+version = "0.5.6"
 description = "Model service for fovea video annotation tool"
 requires-python = ">=3.12"
 dependencies = [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fovea",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "FOVEA - Flexible Ontology Visual Event Analyzer",
   "packageManager": "pnpm@10.15.0",
   "engines": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -857,6 +857,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1633,6 +1651,33 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "error",
+                    "message"
+                  ],
+                  "properties": {
+                    "error": {
+                      "description": "Machine-readable error code",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Human-readable error message",
+                      "type": "string"
+                    },
+                    "details": {
+                      "description": "Additional error context"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -1702,6 +1747,33 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "error",
+                    "message"
+                  ],
+                  "properties": {
+                    "error": {
+                      "description": "Machine-readable error code",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Human-readable error message",
+                      "type": "string"
+                    },
+                    "details": {
+                      "description": "Additional error context"
                     }
                   }
                 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fovea/server",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/prisma/migrations/20260630000000_dedupe_and_uniqueness_constraints/migration.sql
+++ b/server/prisma/migrations/20260630000000_dedupe_and_uniqueness_constraints/migration.sql
@@ -1,0 +1,57 @@
+-- 0.5.6 idempotency / identity hardening.
+--
+-- Adds uniqueness that prevents the duplicate rows the create paths could mint
+-- on retry/race. Each constraint is preceded by a dedupe of any rows that
+-- already violate it (a no-op on a clean database). Partial unique indexes
+-- (ResourceShare, personal WorldState) cannot be expressed in schema.prisma and
+-- are created here as raw SQL; the project applies migrations with
+-- `prisma migrate deploy`, which leaves these in place.
+
+-- ClaimRelation: a (source, target, type) triple must be unique (BUG-13). Drop
+-- duplicates first, keeping one row per triple (ctid breaks ties deterministically).
+DELETE FROM "claim_relations" a
+USING "claim_relations" b
+WHERE a."sourceClaimId" = b."sourceClaimId"
+  AND a."targetClaimId" = b."targetClaimId"
+  AND a."relationTypeId" = b."relationTypeId"
+  AND a.ctid > b.ctid;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "claim_relations_sourceClaimId_targetClaimId_relationTypeId_key" ON "claim_relations"("sourceClaimId", "targetClaimId", "relationTypeId");
+
+-- ResourceShare: a grant of the same resource by the same user to the same
+-- target must be unique (BUG-12). Postgres treats NULLs as distinct, so a single
+-- @@unique cannot constrain the user-share (groupId NULL) and group-share
+-- (userId NULL) cases; use two partial unique indexes. Dedupe first, treating
+-- NULLs as equal (IS NOT DISTINCT FROM), keeping one row per identity.
+DELETE FROM "resource_shares" a
+USING "resource_shares" b
+WHERE a.ctid > b.ctid
+  AND a."resourceType" = b."resourceType"
+  AND a."resourceId" = b."resourceId"
+  AND a."sharedByUserId" = b."sharedByUserId"
+  AND a."sharedWithUserId" IS NOT DISTINCT FROM b."sharedWithUserId"
+  AND a."sharedWithGroupId" IS NOT DISTINCT FROM b."sharedWithGroupId";
+
+CREATE UNIQUE INDEX "resource_shares_user_grant_key"
+  ON "resource_shares"("resourceType", "resourceId", "sharedByUserId", "sharedWithUserId")
+  WHERE "sharedWithGroupId" IS NULL;
+
+CREATE UNIQUE INDEX "resource_shares_group_grant_key"
+  ON "resource_shares"("resourceType", "resourceId", "sharedByUserId", "sharedWithGroupId")
+  WHERE "sharedWithUserId" IS NULL;
+
+-- WorldState: a user has exactly one PERSONAL world state (projectId NULL), but
+-- the compound @@unique([userId, projectId]) does not constrain NULL projectId,
+-- so a concurrent first-write could mint duplicates (BUG-14). Add a partial
+-- unique index on userId where projectId IS NULL. Dedupe first, keeping the
+-- most-recently-updated personal row per user (older duplicates, a rare race
+-- artifact, are removed).
+DELETE FROM "world_state" a
+USING "world_state" b
+WHERE a."projectId" IS NULL AND b."projectId" IS NULL
+  AND a."userId" = b."userId"
+  AND (a."updatedAt" < b."updatedAt" OR (a."updatedAt" = b."updatedAt" AND a.ctid > b.ctid));
+
+CREATE UNIQUE INDEX "world_state_userId_personal_key"
+  ON "world_state"("userId") WHERE "projectId" IS NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -544,6 +544,7 @@ model ClaimRelation {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  @@unique([sourceClaimId, targetClaimId, relationTypeId])
   @@index([sourceClaimId])
   @@index([targetClaimId])
   @@index([relationTypeId])

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -14,6 +14,7 @@ import { apiRequestCounter, apiRequestDuration } from './metrics.js'
 import { config } from './config.js'
 import { prisma } from './lib/prisma.js'
 import { AppError, TooManyRequestsError } from './lib/errors.js'
+import { requireAdmin } from './middleware/auth.js'
 import { recordApiError } from './lib/errorMetrics.js'
 
 /**
@@ -39,7 +40,7 @@ import { recordApiError } from './lib/errorMetrics.js'
  */
 export async function buildApp() {
   const app = Fastify({
-    trustProxy: true,
+    trustProxy: config.server.trustProxy,
     logger: {
       level: config.server.logLevel,
       transport: !config.server.isProduction ? {
@@ -116,7 +117,11 @@ export async function buildApp() {
     }
   })
 
-  // Bull Board queue monitoring
+  // Bull Board queue monitoring. The dashboard exposes job payloads (video and
+  // persona ids, model prompts, error stacks) and Bull Board's mutating actions
+  // (retry/promote/clean/remove), so it MUST NOT be world-readable. Register it
+  // inside an encapsulated child context whose onRequest hook requires admin —
+  // the only authorization that applies to the bull-board plugin's own routes.
   const serverAdapter = new FastifyAdapter()
   createBullBoard({
     queues: [
@@ -126,7 +131,10 @@ export async function buildApp() {
     serverAdapter,
   })
   serverAdapter.setBasePath('/admin/queues')
-  await app.register(serverAdapter.registerPlugin(), { prefix: '/admin/queues' })
+  await app.register(async (queueScope) => {
+    queueScope.addHook('onRequest', requireAdmin)
+    await queueScope.register(serverAdapter.registerPlugin(), { prefix: '/admin/queues' })
+  })
 
   // Decorate Fastify instance with Prisma client
   app.decorate('prisma', prisma)

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -307,6 +307,23 @@ const config = Object.freeze({
     get logLevel(): string {
       return readStringWithDefault('LOG_LEVEL', 'info')
     },
+    /**
+     * Value passed to Fastify's `trustProxy`. Controls whether `X-Forwarded-For`
+     * is trusted for `request.ip` (which keys per-IP rate limiting and login
+     * throttling). `true` trusts ALL upstreams, making the header — and thus the
+     * rate-limit key — attacker-spoofable; default to trusting a single proxy
+     * hop instead. Set `TRUST_PROXY` to a hop count, a comma-separated list of
+     * trusted proxy IPs/CIDRs, or `true`/`false` to match the deployment.
+     */
+    get trustProxy(): boolean | number | string {
+      const raw = process.env.TRUST_PROXY
+      if (raw === undefined || raw === '') return 1
+      if (raw === 'true') return true
+      if (raw === 'false') return false
+      const n = Number.parseInt(raw, 10)
+      if (Number.isFinite(n) && String(n) === raw.trim()) return n
+      return raw
+    },
   }),
 
   redis: Object.freeze({

--- a/server/src/demo/seed.ts
+++ b/server/src/demo/seed.ts
@@ -130,7 +130,11 @@ const seedPlugin: FastifyPluginAsync = async (app: FastifyInstance) => {
           type: 'object',
           required: ['tourId', 'sessionUserId'],
           properties: {
-            tourId: { type: 'string', minLength: 1, maxLength: 64 },
+            // Strict charset: tourId is interpolated into a fixture filename
+            // (`tour-${tourId}.json`), so it must not contain path separators or
+            // `.` — otherwise a crafted id could traverse outside the fixtures
+            // dir. A bare tour id is lowercase-alphanumeric with hyphens.
+            tourId: { type: 'string', pattern: '^[a-z0-9][a-z0-9-]{0,63}$' },
             sessionUserId: { type: 'string', minLength: 1, maxLength: 64 },
           },
         },

--- a/server/src/lib/errors.ts
+++ b/server/src/lib/errors.ts
@@ -16,6 +16,7 @@
  */
 
 import { Type, Static } from '@sinclair/typebox'
+import type { Prisma } from '@prisma/client'
 
 /**
  * Standard error response schema for OpenAPI documentation.
@@ -152,6 +153,41 @@ export class ConflictError extends AppError {
   constructor(message: string, details?: unknown) {
     super(409, 'CONFLICT', message, details)
   }
+}
+
+/**
+ * Build a human-readable 409 message from a Prisma `P2002` unique-constraint
+ * violation. `error.meta.target` names the conflicting column(s) (or, for a
+ * named index, the constraint name); pass `labels` to map a field substring to
+ * a friendly message (e.g. `{ email: 'A user with this email already exists' }`).
+ *
+ * @example
+ * ```typescript
+ * catch (e) {
+ *   if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+ *     throw new ConflictError(conflictMessageFromP2002(e, { email: 'Email already in use' }))
+ *   }
+ * }
+ * ```
+ */
+export function conflictMessageFromP2002(
+  error: Prisma.PrismaClientKnownRequestError,
+  labels: Record<string, string> = {}
+): string {
+  const target = error.meta?.target
+  const fields = Array.isArray(target)
+    ? target.map(String)
+    : typeof target === 'string'
+      ? [target]
+      : []
+  for (const [key, message] of Object.entries(labels)) {
+    if (fields.some((f) => f.toLowerCase().includes(key.toLowerCase()))) {
+      return message
+    }
+  }
+  return fields.length
+    ? `A record with this ${fields.join(', ')} already exists`
+    : 'A record with these values already exists'
 }
 
 /**

--- a/server/src/repositories/PersonaRepository.ts
+++ b/server/src/repositories/PersonaRepository.ts
@@ -138,6 +138,44 @@ export class PersonaRepository {
   }
 
   /**
+   * Applies an optimistic-concurrency update to a persona's ontology row.
+   *
+   * Reads the current ontology row (by personaId), lets `transform` compute the
+   * new column values from it, then writes them guarded by the row's
+   * `updatedAt`. If a concurrent writer committed first the guard misses (count
+   * 0) and we retry against the freshly-read row, so both writes land instead of
+   * one silently clobbering the other. This is what makes the whole-blob
+   * ontology PUT a safe per-id merge under concurrent writers (the transform
+   * re-runs on fresh state each attempt).
+   *
+   * @param personaId - Persona UUID owning the ontology
+   * @param transform - computes the Prisma update input from the current row
+   * @returns the updated ontology
+   * @throws when no ontology row exists or the write keeps conflicting
+   */
+  async updateOntologyOptimistic(
+    personaId: string,
+    transform: (current: Ontology) => Prisma.OntologyUpdateInput,
+  ): Promise<Ontology> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const current = await this.prisma.ontology.findUnique({
+        where: { personaId },
+      })
+      if (!current) {
+        throw new Error('No ontology to update')
+      }
+      const result = await this.prisma.ontology.updateMany({
+        where: { id: current.id, updatedAt: current.updatedAt },
+        data: { ...transform(current), updatedAt: new Date() },
+      })
+      if (result.count === 1) {
+        return this.prisma.ontology.findUniqueOrThrow({ where: { id: current.id } })
+      }
+    }
+    throw new Error('Ontology update conflicted after retries')
+  }
+
+  /**
    * Counts annotations matching a WHERE clause.
    *
    * @param where - Prisma annotation WHERE clause

--- a/server/src/repositories/ProjectRepository.ts
+++ b/server/src/repositories/ProjectRepository.ts
@@ -409,21 +409,76 @@ export class ProjectRepository {
   }
 
   /**
-   * Updates the caller's world state in a project.
+   * Gets-or-creates the caller's empty world state for a project, keyed on the
+   * compound unique (userId, projectId).
+   *
+   * Using upsert (rather than find-then-create) makes concurrent first access
+   * safe: two callers that both miss the row would, with a separate create,
+   * race into the `@@unique([userId, projectId])` constraint (P2002). The
+   * upsert collapses that into a single atomic statement, leaving the existing
+   * row untouched on a hit and creating the empty arrays on a miss.
    *
    * @param userId - the caller
    * @param projectId - Project UUID
-   * @param data - Prisma world state update input
-   * @returns the updated world state
+   * @returns the existing or newly-created world state
    */
-  async updateWorldState(
+  async upsertEmptyWorldState(userId: string, projectId: string): Promise<WorldState> {
+    return this.prisma.worldState.upsert({
+      where: { userId_projectId: { userId, projectId } },
+      create: {
+        userId,
+        projectId,
+        entities: [],
+        events: [],
+        times: [],
+        entityCollections: [],
+        eventCollections: [],
+        timeCollections: [],
+        relations: [],
+      },
+      update: {},
+    })
+  }
+
+  /**
+   * Applies an optimistic-concurrency update to the caller's project world
+   * state.
+   *
+   * Reads the current (userId, projectId) row, lets `transform` compute the new
+   * column values from it, then writes them guarded by the row's `updatedAt`.
+   * If a concurrent writer committed first the guard misses (count 0) and we
+   * retry against the freshly-read row, so both writes land instead of one
+   * silently clobbering the other. Project world state is multi-user (every
+   * member shares the row), which makes this guard essential for the whole-blob
+   * PUT to be a safe per-id merge under concurrent writers (the transform
+   * re-runs on fresh state each attempt).
+   *
+   * @param userId - the caller
+   * @param projectId - Project UUID
+   * @param transform - computes the Prisma update input from the current row
+   * @returns the updated world state
+   * @throws when no project row exists or the write keeps conflicting
+   */
+  async updateProjectWorldStateOptimistic(
     userId: string,
     projectId: string,
-    data: Prisma.WorldStateUpdateInput
+    transform: (current: WorldState) => Prisma.WorldStateUpdateInput,
   ): Promise<WorldState> {
-    return this.prisma.worldState.update({
-      where: { userId_projectId: { userId, projectId } },
-      data,
-    })
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const current = await this.prisma.worldState.findUnique({
+        where: { userId_projectId: { userId, projectId } },
+      })
+      if (!current) {
+        throw new Error('No project world state to update')
+      }
+      const result = await this.prisma.worldState.updateMany({
+        where: { userId, projectId, updatedAt: current.updatedAt },
+        data: { ...transform(current), updatedAt: new Date() },
+      })
+      if (result.count === 1) {
+        return this.prisma.worldState.findUniqueOrThrow({ where: { id: current.id } })
+      }
+    }
+    throw new Error('Project world state update conflicted after retries')
   }
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify'
 import bcrypt from 'bcrypt'
 import { Type } from '@sinclair/typebox'
+import { Prisma } from '@prisma/client'
 import { authService } from '../services/auth-service.js'
 import { lockoutService } from '../services/lockout-service.js'
 import { prisma } from '../lib/prisma.js'
@@ -9,6 +10,7 @@ import {
   ForbiddenError,
   ConflictError,
   TooManyRequestsError,
+  conflictMessageFromP2002,
 } from '../lib/errors.js'
 import {
   recordLoginAttempt,
@@ -334,6 +336,9 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
           403: Type.Object({
             error: Type.String(),
           }),
+          409: Type.Object({
+            error: Type.String(),
+          }),
         },
       },
     },
@@ -357,16 +362,29 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       // Hash password
       const passwordHash = await bcrypt.hash(password, 12)
 
-      // Create user
-      const user = await prisma.user.create({
-        data: {
-          username,
-          email: email || null,
-          passwordHash,
-          displayName,
-          isAdmin: false,
-        },
-      })
+      // Create user. The pre-check narrows the common case, but a duplicate
+      // username can still race past it, and a duplicate email is not pre-checked
+      // at all — translate the unique violation to 409 instead of a 500.
+      let user
+      try {
+        user = await prisma.user.create({
+          data: {
+            username,
+            email: email || null,
+            passwordHash,
+            displayName,
+            isAdmin: false,
+          },
+        })
+      } catch (error: unknown) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          throw new ConflictError(conflictMessageFromP2002(error, {
+            email: 'An account with this email already exists',
+            username: 'Username already exists',
+          }))
+        }
+        throw error
+      }
 
       // Create session so the user is logged in immediately after registration
       const { token, expiresAt } = await authService.regenerateSession('', user.id, {

--- a/server/src/routes/groups.ts
+++ b/server/src/routes/groups.ts
@@ -10,7 +10,7 @@
 
 import { Type, Static } from '@sinclair/typebox'
 import { FastifyPluginAsync } from 'fastify'
-import { PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 
 import { requireAuth, requireAdmin } from '../middleware/auth.js'
 import { groupOperationCounter } from '../metrics.js'
@@ -218,38 +218,48 @@ const groupsRoute: FastifyPluginAsync = async (fastify) => {
         )
       }
 
-      // Create group and owner membership in a transaction
-      const group = await fastify.prisma.$transaction(async (tx) => {
-        const created = await tx.userGroup.create({
-          data: {
-            name,
-            description: description ?? null,
-            slug,
-            createdBy: userId,
-          },
-        })
+      // Create group and owner membership in a transaction. The slug pre-check
+      // narrows the common case, but a concurrent create with the same slug can
+      // still race past it — translate the unique violation to 409 rather than 500.
+      let group
+      try {
+        group = await fastify.prisma.$transaction(async (tx) => {
+          const created = await tx.userGroup.create({
+            data: {
+              name,
+              description: description ?? null,
+              slug,
+              createdBy: userId,
+            },
+          })
 
-        await tx.groupMembership.create({
-          data: {
-            userId,
-            groupId: created.id,
-            role: 'group_owner',
-          },
-        })
+          await tx.groupMembership.create({
+            data: {
+              userId,
+              groupId: created.id,
+              role: 'group_owner',
+            },
+          })
 
-        return tx.userGroup.findUniqueOrThrow({
-          where: { id: created.id },
-          include: {
-            members: {
-              include: {
-                user: {
-                  select: { id: true, username: true, displayName: true, email: true },
+          return tx.userGroup.findUniqueOrThrow({
+            where: { id: created.id },
+            include: {
+              members: {
+                include: {
+                  user: {
+                    select: { id: true, username: true, displayName: true, email: true },
+                  },
                 },
               },
             },
-          },
+          })
         })
-      })
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          throw new ConflictError(`A group with slug "${slug}" already exists. Choose a different slug.`)
+        }
+        throw error
+      }
 
       // Creator's abilities changed (they are now a group_owner)
       invalidateUserAbilities(userId)
@@ -835,37 +845,45 @@ const groupsRoute: FastifyPluginAsync = async (fastify) => {
         throw new NotFoundError('User', createdBy)
       }
 
-      const group = await fastify.prisma.$transaction(async (tx) => {
-        const created = await tx.userGroup.create({
-          data: {
-            name,
-            description: description ?? null,
-            slug,
-            createdBy,
-          },
-        })
+      let group
+      try {
+        group = await fastify.prisma.$transaction(async (tx) => {
+          const created = await tx.userGroup.create({
+            data: {
+              name,
+              description: description ?? null,
+              slug,
+              createdBy,
+            },
+          })
 
-        await tx.groupMembership.create({
-          data: {
-            userId: createdBy,
-            groupId: created.id,
-            role: 'group_owner',
-          },
-        })
+          await tx.groupMembership.create({
+            data: {
+              userId: createdBy,
+              groupId: created.id,
+              role: 'group_owner',
+            },
+          })
 
-        return tx.userGroup.findUniqueOrThrow({
-          where: { id: created.id },
-          include: {
-            members: {
-              include: {
-                user: {
-                  select: { id: true, username: true, displayName: true, email: true },
+          return tx.userGroup.findUniqueOrThrow({
+            where: { id: created.id },
+            include: {
+              members: {
+                include: {
+                  user: {
+                    select: { id: true, username: true, displayName: true, email: true },
+                  },
                 },
               },
             },
-          },
+          })
         })
-      })
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          throw new ConflictError(`A group with slug "${slug}" already exists. Choose a different slug.`)
+        }
+        throw error
+      }
 
       // Admin-created group: the designated owner's abilities changed
       invalidateUserAbilities(createdBy)

--- a/server/src/routes/ontology.ts
+++ b/server/src/routes/ontology.ts
@@ -13,6 +13,9 @@ import {
   ModelServiceTimeoutError,
   ModelServiceUnreachableError,
 } from '../lib/fetchModelService.js'
+import { mergeById } from '../services/world-state-service.js'
+import { PersonaRepository } from '../repositories/PersonaRepository.js'
+import { WorldStateRepository } from '../repositories/WorldStateRepository.js'
 import camelcaseKeys from 'camelcase-keys'
 
 /**
@@ -60,6 +63,12 @@ const WorldSchema = Type.Object({
  * - POST /api/ontology/augment - Generate AI-powered type suggestions
  */
 const ontologyRoute: FastifyPluginAsync = async (fastify) => {
+  // Request-independent: one repository each for the plugin's lifetime. These
+  // own the updatedAt-guarded optimistic merges the combined save routes
+  // through so concurrent edits do not clobber each other.
+  const personaRepository = new PersonaRepository(fastify.prisma)
+  const worldStateRepository = new WorldStateRepository(fastify.prisma)
+
   /**
    * Get all personas, their ontologies, and world state.
    * Returns data in the multi-persona format expected by the frontend.
@@ -246,21 +255,28 @@ const ontologyRoute: FastifyPluginAsync = async (fastify) => {
       world?: WorldInput
     }
 
-    // Use a transaction to ensure atomicity - either all saves succeed or all fail
+    // This multi-entity save merges ontology types and personal world state by
+    // id instead of overwriting whole columns, under optimistic concurrency, so
+    // concurrent edits (rapid edits, an AI augmentation, or a second tab) do not
+    // clobber each other. Removals go through the explicit type/object deletion
+    // routes, never omission. Personas carry only scalar fields and so are safe
+    // to upsert directly. The ontology and world writes each self-retry on an
+    // updatedAt-guarded conflict, which is why a single raw transaction is no
+    // longer used: correctness (no lost updates) takes priority over wrapping
+    // all writes in one atomic statement.
     try {
-      const result = await fastify.prisma.$transaction(async (tx) => {
-        const savedPersonas = []
-        const savedOntologies = []
+      const savedPersonas = []
+      const savedOntologies = []
 
       // Save all personas for this user, verifying RBAC on existing ones
       for (const persona of personas) {
-        const existing = await tx.persona.findUnique({ where: { id: persona.id } })
+        const existing = await fastify.prisma.persona.findUnique({ where: { id: persona.id } })
         if (existing) {
           if (!request.ability!.can('update', subject('Persona', existing))) {
             throw new ForbiddenError('Cannot update persona ' + persona.id)
           }
         }
-        const savedPersona = await tx.persona.upsert({
+        const savedPersona = await fastify.prisma.persona.upsert({
           where: { id: persona.id },
           update: {
             name: persona.name,
@@ -280,31 +296,40 @@ const ontologyRoute: FastifyPluginAsync = async (fastify) => {
         savedPersonas.push(savedPersona)
       }
 
-      // Save all ontologies, verifying the caller can update the owning persona
+      // Save all ontologies, verifying the caller can update the owning persona.
+      // Each provided array is merged into the current row by id under
+      // optimistic concurrency; a row that does not exist yet is created.
       for (const ontology of personaOntologies) {
-        const owningPersona = await tx.persona.findUnique({ where: { id: ontology.personaId } })
+        const owningPersona = await fastify.prisma.persona.findUnique({ where: { id: ontology.personaId } })
         if (!owningPersona) {
           throw new NotFoundError('Persona', ontology.personaId)
         }
         if (!request.ability!.can('update', subject('Persona', owningPersona))) {
           throw new ForbiddenError('Cannot modify ontology for persona ' + ontology.personaId)
         }
-        const savedOntology = await tx.ontology.upsert({
-          where: { personaId: ontology.personaId },
-          update: {
-            entityTypes: ontology.entities || [],
-            roleTypes: ontology.roles || [],
-            eventTypes: ontology.events || [],
-            relationTypes: ontology.relationTypes || []
-          },
-          create: {
-            personaId: ontology.personaId,
-            entityTypes: ontology.entities || [],
-            roleTypes: ontology.roles || [],
-            eventTypes: ontology.events || [],
-            relationTypes: ontology.relationTypes || []
-          }
+
+        let savedOntology
+        const existingOntology = await fastify.prisma.ontology.findUnique({
+          where: { personaId: ontology.personaId }
         })
+        if (existingOntology) {
+          savedOntology = await personaRepository.updateOntologyOptimistic(ontology.personaId, (current) => ({
+            entityTypes: ontology.entities !== undefined ? mergeById(current.entityTypes, ontology.entities) : undefined,
+            roleTypes: ontology.roles !== undefined ? mergeById(current.roleTypes, ontology.roles) : undefined,
+            eventTypes: ontology.events !== undefined ? mergeById(current.eventTypes, ontology.events) : undefined,
+            relationTypes: ontology.relationTypes !== undefined ? mergeById(current.relationTypes, ontology.relationTypes) : undefined,
+          }))
+        } else {
+          savedOntology = await fastify.prisma.ontology.create({
+            data: {
+              personaId: ontology.personaId,
+              entityTypes: ontology.entities || [],
+              roleTypes: ontology.roles || [],
+              eventTypes: ontology.events || [],
+              relationTypes: ontology.relationTypes || []
+            }
+          })
+        }
         savedOntologies.push({
           id: savedOntology.id,
           personaId: savedOntology.personaId,
@@ -318,37 +343,41 @@ const ontologyRoute: FastifyPluginAsync = async (fastify) => {
         })
       }
 
-      // Save world state if provided (for this user)
+      // Save world state if provided (for this user). Merge each array by id
+      // under optimistic concurrency; create an empty-seeded row if none exists.
       let savedWorldState = null
       if (world) {
-        const existingWorld = await tx.worldState.findFirst({
+        const existingWorld = await fastify.prisma.worldState.findFirst({
           where: { userId, projectId: null }
         })
 
-        const worldData = {
-          entities: world.entities || [],
-          events: world.events || [],
-          times: world.times || [],
-          entityCollections: world.entityCollections || [],
-          eventCollections: world.eventCollections || [],
-          timeCollections: world.timeCollections || [],
-          relations: world.relations || []
-        }
-
         if (existingWorld) {
-          savedWorldState = await tx.worldState.update({
-            where: { id: existingWorld.id },
-            data: worldData
-          })
+          savedWorldState = await worldStateRepository.updatePersonalWorldStateOptimistic(userId, (current) => ({
+            entities: world.entities !== undefined ? mergeById(current.entities, world.entities) : undefined,
+            events: world.events !== undefined ? mergeById(current.events, world.events) : undefined,
+            times: world.times !== undefined ? mergeById(current.times, world.times) : undefined,
+            entityCollections: world.entityCollections !== undefined ? mergeById(current.entityCollections, world.entityCollections) : undefined,
+            eventCollections: world.eventCollections !== undefined ? mergeById(current.eventCollections, world.eventCollections) : undefined,
+            timeCollections: world.timeCollections !== undefined ? mergeById(current.timeCollections, world.timeCollections) : undefined,
+            relations: world.relations !== undefined ? mergeById(current.relations, world.relations) : undefined,
+          }))
         } else {
-          savedWorldState = await tx.worldState.create({
-            data: { userId, ...worldData }
+          savedWorldState = await fastify.prisma.worldState.create({
+            data: {
+              userId,
+              entities: world.entities || [],
+              events: world.events || [],
+              times: world.times || [],
+              entityCollections: world.entityCollections || [],
+              eventCollections: world.eventCollections || [],
+              timeCollections: world.timeCollections || [],
+              relations: world.relations || []
+            }
           })
         }
       }
 
-        return { savedPersonas, savedOntologies, savedWorldState }
-      })
+      const result = { savedPersonas, savedOntologies, savedWorldState }
 
       const worldData = result.savedWorldState ? {
         entities: (result.savedWorldState.entities as Prisma.JsonArray) || [],

--- a/server/src/routes/sharing.ts
+++ b/server/src/routes/sharing.ts
@@ -16,6 +16,120 @@ import { Prisma, PrismaClient } from '@prisma/client'
 function toJson(value: unknown): Prisma.InputJsonValue {
   return JSON.parse(JSON.stringify(value))
 }
+
+/**
+ * Deep-forks a persona (and its ontology) into a new persona owned by
+ * `ownerUserId`.
+ *
+ * The forked persona is a fresh row: it copies the source's name, role,
+ * information need, details, and ontology arrays, but is marked
+ * non-system-generated and visible. The new persona is what lets summary,
+ * claim, and annotation forks land in the forker's own scope instead of
+ * pointing back at the sharer's persona (which would either collide on a
+ * unique constraint or orphan the forked resource under another user).
+ *
+ * @param tx - the Prisma transaction client running the fork
+ * @param sourcePersonaId - UUID of the persona to copy
+ * @param ownerUserId - UUID of the user who will own the forked persona
+ * @returns the id of the newly created persona
+ * @throws {NotFoundError} when the source persona does not exist
+ */
+async function forkPersona(
+  tx: Prisma.TransactionClient,
+  sourcePersonaId: string,
+  ownerUserId: string
+): Promise<{ id: string }> {
+  const source = await tx.persona.findUnique({
+    where: { id: sourcePersonaId },
+    include: { ontology: true },
+  })
+  if (!source) {
+    throw new NotFoundError('Persona', sourcePersonaId)
+  }
+  return tx.persona.create({
+    data: {
+      userId: ownerUserId,
+      name: source.name,
+      role: source.role,
+      informationNeed: source.informationNeed,
+      details: source.details,
+      isSystemGenerated: false,
+      hidden: false,
+      ontology: source.ontology
+        ? {
+            create: {
+              entityTypes: toJson(source.ontology.entityTypes),
+              eventTypes: toJson(source.ontology.eventTypes),
+              roleTypes: toJson(source.ontology.roleTypes),
+              relationTypes: toJson(source.ontology.relationTypes),
+            },
+          }
+        : {
+            create: {
+              entityTypes: [],
+              eventTypes: [],
+              roleTypes: [],
+              relationTypes: [],
+            },
+          },
+    },
+    select: { id: true },
+  })
+}
+
+/**
+ * Deep-forks a video summary into the forker's own scope.
+ *
+ * The source summary's persona belongs to the sharer, and VideoSummary carries
+ * a unique constraint on (videoId, personaId). Reusing the source's personaId
+ * would therefore collide with the source row. This helper forks the persona
+ * first (a new persona owned by `ownerUserId`) and then creates the forked
+ * summary against the NEW personaId, keeping the same videoId; the new
+ * (videoId, personaId) pair is unique, so no collision occurs. The schema
+ * requires personaId, so a summary always has a persona to fork.
+ *
+ * @param tx - the Prisma transaction client running the fork
+ * @param sourceSummaryId - UUID of the summary to copy
+ * @param ownerUserId - UUID of the user who will own the forked summary
+ * @returns the id of the newly created summary
+ * @throws {NotFoundError} when the source summary does not exist
+ */
+async function forkSummary(
+  tx: Prisma.TransactionClient,
+  sourceSummaryId: string,
+  ownerUserId: string
+): Promise<{ id: string }> {
+  const source = await tx.videoSummary.findUnique({
+    where: { id: sourceSummaryId },
+  })
+  if (!source) {
+    throw new NotFoundError('VideoSummary', sourceSummaryId)
+  }
+
+  // A summary's persona belongs to the sharer; fork it so the forked summary
+  // lands in the forker's scope under a NEW personaId, keeping the same videoId.
+  const forkedPersona = await forkPersona(tx, source.personaId, ownerUserId)
+
+  return tx.videoSummary.create({
+    data: {
+      videoId: source.videoId,
+      personaId: forkedPersona.id,
+      summary: toJson(source.summary ?? []),
+      visualAnalysis: source.visualAnalysis,
+      audioTranscript: source.audioTranscript,
+      keyFrames: source.keyFrames ? toJson(source.keyFrames) : Prisma.JsonNull,
+      confidence: source.confidence,
+      transcriptJson: source.transcriptJson
+        ? toJson(source.transcriptJson)
+        : Prisma.JsonNull,
+      audioLanguage: source.audioLanguage,
+      speakerCount: source.speakerCount,
+      comment: source.comment,
+      createdBy: ownerUserId,
+    },
+    select: { id: true },
+  })
+}
 import { trace } from '@opentelemetry/api'
 import { requireAuth } from '@middleware/auth.js'
 import { sharingOperationCounter } from '../metrics.js'
@@ -704,12 +818,20 @@ const sharingRoute: FastifyPluginAsync = async (fastify) => {
             if (!source) {
               throw new NotFoundError('Annotation', share.resourceId)
             }
+            // Type annotations carry a persona (the sharer's); fork it so the
+            // forked annotation points at the forker's own persona. Object
+            // annotations are persona-agnostic (personaId null); keep them null
+            // and just re-own them under the forker.
+            const forkedPersonaId = source.personaId
+              ? (await forkPersona(tx, source.personaId, userId)).id
+              : null
             return tx.annotation.create({
               data: {
                 videoId: source.videoId,
-                personaId: source.personaId,
+                personaId: forkedPersonaId,
                 type: source.type,
                 label: source.label,
+                linkType: source.linkType,
                 frames: toJson(source.frames),
                 confidence: source.confidence,
                 source: source.source,
@@ -719,32 +841,22 @@ const sharingRoute: FastifyPluginAsync = async (fastify) => {
           }
 
           case 'summary': {
-            const source = await tx.videoSummary.findUnique({
-              where: { id: share.resourceId },
+            // Deep-fork: fork the source summary's persona into the forker's
+            // scope, then create the forked summary against the NEW personaId.
+            // Reusing the source's (videoId, personaId) would collide on the
+            // VideoSummary unique constraint, so the persona must be new.
+            const { id: forkedSummaryId } = await forkSummary(
+              tx,
+              share.resourceId,
+              userId
+            )
+            const forked = await tx.videoSummary.findUnique({
+              where: { id: forkedSummaryId },
             })
-            if (!source) {
-              throw new NotFoundError('VideoSummary', share.resourceId)
+            if (!forked) {
+              throw new NotFoundError('VideoSummary', forkedSummaryId)
             }
-            return tx.videoSummary.create({
-              data: {
-                videoId: source.videoId,
-                personaId: source.personaId,
-                summary: toJson(source.summary ?? []),
-                visualAnalysis: source.visualAnalysis,
-                audioTranscript: source.audioTranscript,
-                keyFrames: source.keyFrames
-                  ? toJson(source.keyFrames)
-                  : Prisma.JsonNull,
-                confidence: source.confidence,
-                transcriptJson: source.transcriptJson
-                  ? toJson(source.transcriptJson)
-                  : Prisma.JsonNull,
-                audioLanguage: source.audioLanguage,
-                speakerCount: source.speakerCount,
-                comment: source.comment,
-                createdBy: userId,
-              },
-            })
+            return forked
           }
 
           case 'claim': {
@@ -754,9 +866,21 @@ const sharingRoute: FastifyPluginAsync = async (fastify) => {
             if (!source) {
               throw new NotFoundError('Claim', share.resourceId)
             }
-            return tx.claim.create({
+
+            // Deep-fork: fork the source claim's parent summary into the
+            // forker's scope (which forks its persona), then create the forked
+            // claim under the NEW summaryId. Reusing the sharer's summaryId
+            // would orphan the claim under another user's summary, so it would
+            // never appear in the forker's tree.
+            const { id: forkedSummaryId } = await forkSummary(
+              tx,
+              source.summaryId,
+              userId
+            )
+
+            const forkedClaim = await tx.claim.create({
               data: {
-                summaryId: source.summaryId,
+                summaryId: forkedSummaryId,
                 summaryType: source.summaryType,
                 text: source.text,
                 gloss: toJson(source.gloss),
@@ -788,45 +912,51 @@ const sharingRoute: FastifyPluginAsync = async (fastify) => {
                 createdBy: userId,
               },
             })
+
+            // Rebuild the forked summary's denormalized claimsJson so the
+            // forked claim is visible in the forker's tree. This version forks
+            // a single root claim (no subclaims), so the tree holds exactly one
+            // root with an empty subclaim list, mirroring the shape produced by
+            // ClaimService.updateSummaryClaimsJson.
+            const treeNode = { ...forkedClaim, subclaims: [] }
+            const claimsJson = {
+              version: '1.0',
+              claims: [treeNode],
+              metadata: {
+                extractedAt: new Date().toISOString(),
+                totalClaims: 1,
+                totalSubclaims: 0,
+                maxDepth: 0,
+              },
+            }
+            await tx.videoSummary.update({
+              where: { id: forkedSummaryId },
+              data: {
+                claimsJson: toJson(claimsJson),
+                claimsExtractedAt: new Date(),
+              },
+            })
+
+            return forkedClaim
           }
 
           case 'persona': {
-            const source = await tx.persona.findUnique({
-              where: { id: share.resourceId },
+            // Reuse the shared persona-copy helper so the copy logic lives in
+            // one place, then load the forked persona with its ontology to
+            // return the full resource.
+            const { id: forkedPersonaId } = await forkPersona(
+              tx,
+              share.resourceId,
+              userId
+            )
+            const forked = await tx.persona.findUnique({
+              where: { id: forkedPersonaId },
               include: { ontology: true },
             })
-            if (!source) {
-              throw new NotFoundError('Persona', share.resourceId)
+            if (!forked) {
+              throw new NotFoundError('Persona', forkedPersonaId)
             }
-            return tx.persona.create({
-              data: {
-                userId,
-                name: source.name,
-                role: source.role,
-                informationNeed: source.informationNeed,
-                details: source.details,
-                isSystemGenerated: false,
-                hidden: false,
-                ontology: source.ontology
-                  ? {
-                      create: {
-                        entityTypes: toJson(source.ontology.entityTypes),
-                        eventTypes: toJson(source.ontology.eventTypes),
-                        roleTypes: toJson(source.ontology.roleTypes),
-                        relationTypes: toJson(source.ontology.relationTypes),
-                      },
-                    }
-                  : {
-                      create: {
-                        entityTypes: [],
-                        eventTypes: [],
-                        roleTypes: [],
-                        relationTypes: [],
-                      },
-                    },
-              },
-              include: { ontology: true },
-            })
+            return forked
           }
 
           case 'world_state': {

--- a/server/src/routes/sharing.ts
+++ b/server/src/routes/sharing.ts
@@ -30,6 +30,7 @@ import {
   ForbiddenError,
   ErrorResponseSchema,
 } from '@lib/errors.js'
+import { mergeById } from '../services/world-state-service.js'
 
 const tracer = trace.getTracer('fovea-rbac')
 
@@ -387,16 +388,45 @@ const sharingRoute: FastifyPluginAsync = async (fastify) => {
         }
       }
 
-      const share = await fastify.prisma.resourceShare.create({
-        data: {
-          resourceType,
-          resourceId,
-          sharedByUserId: userId,
-          sharedWithUserId: sharedWithUserId || null,
-          sharedWithGroupId: sharedWithGroupId || null,
-          permissionLevel,
-        },
-      })
+      // Sharing the same resource to the same target is idempotent: re-issuing a
+      // grant must not accumulate duplicate ResourceShare rows (which would make
+      // /received and /sent list the resource twice, leave it shared after one is
+      // revoked, and double-fire ability invalidation). Reuse an existing grant,
+      // updating only its permission level; a partial unique index backstops the
+      // concurrent-create race below.
+      const shareIdentity = {
+        resourceType,
+        resourceId,
+        sharedByUserId: userId,
+        sharedWithUserId: sharedWithUserId || null,
+        sharedWithGroupId: sharedWithGroupId || null,
+      }
+      const existingShare = await fastify.prisma.resourceShare.findFirst({ where: shareIdentity })
+      let share
+      if (existingShare) {
+        share = existingShare.permissionLevel === permissionLevel
+          ? existingShare
+          : await fastify.prisma.resourceShare.update({
+              where: { id: existingShare.id },
+              data: { permissionLevel },
+            })
+      } else {
+        try {
+          share = await fastify.prisma.resourceShare.create({
+            data: { ...shareIdentity, permissionLevel },
+          })
+        } catch (error) {
+          // Lost a concurrent create race against the partial unique index — the
+          // other writer's row is the canonical grant; re-read and return it.
+          if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+            const winner = await fastify.prisma.resourceShare.findFirst({ where: shareIdentity })
+            if (!winner) throw error
+            share = winner
+          } else {
+            throw error
+          }
+        }
+      }
 
       // Invalidate ability caches for the new grantee so access takes effect
       // immediately. Caches are keyed per user, so we expand group targets.
@@ -805,6 +835,27 @@ const sharingRoute: FastifyPluginAsync = async (fastify) => {
             })
             if (!source) {
               throw new NotFoundError('WorldState', share.resourceId)
+            }
+            // A user has exactly one personal world state (projectId NULL), so a
+            // fork cannot mint a second one — it would collide on the personal
+            // partial unique index. Merge the shared content into the forker's
+            // existing personal row by id (additive); create it only if absent.
+            const existing = await tx.worldState.findFirst({
+              where: { userId, projectId: null },
+            })
+            if (existing) {
+              return tx.worldState.update({
+                where: { id: existing.id },
+                data: {
+                  entities: mergeById(existing.entities, source.entities as unknown[]),
+                  events: mergeById(existing.events, source.events as unknown[]),
+                  times: mergeById(existing.times, source.times as unknown[]),
+                  entityCollections: mergeById(existing.entityCollections, source.entityCollections as unknown[]),
+                  eventCollections: mergeById(existing.eventCollections, source.eventCollections as unknown[]),
+                  timeCollections: mergeById(existing.timeCollections, source.timeCollections as unknown[]),
+                  relations: mergeById(existing.relations, source.relations as unknown[]),
+                },
+              })
             }
             return tx.worldState.create({
               data: {

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -4,7 +4,10 @@ import { z } from 'zod'
 import bcrypt from 'bcrypt'
 import { requireAuth, requireAdmin } from '../middleware/auth.js'
 import { invalidateUserAbilities } from '../middleware/abilities.js'
-import { NotFoundError, UnauthorizedError, ForbiddenError, ConflictError } from '../lib/errors.js'
+import { NotFoundError, UnauthorizedError, ForbiddenError, ConflictError, conflictMessageFromP2002, ErrorResponseSchema } from '../lib/errors.js'
+import { authService } from '../services/auth-service.js'
+import { config } from '../config.js'
+import { Prisma } from '@prisma/client'
 
 /**
  * TypeBox schema for User response.
@@ -185,6 +188,24 @@ const usersRoute: FastifyPluginAsync = async (fastify) => {
       }
     })
 
+    // A password change must invalidate every existing session so a stolen or
+    // shared token cannot survive the reset. Revoke all of this user's sessions,
+    // then re-issue a fresh one for the acting client so they stay logged in.
+    if (validatedData.password) {
+      await authService.revokeAllUserSessions(request.user.id)
+      const { token, expiresAt } = await authService.createSession(request.user.id, {
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      })
+      reply.setCookie('session_token', token, {
+        httpOnly: true,
+        secure: config.server.isProduction,
+        sameSite: 'lax',
+        expires: expiresAt,
+        path: '/',
+      })
+    }
+
     return reply.send(user)
   })
 
@@ -268,26 +289,39 @@ const usersRoute: FastifyPluginAsync = async (fastify) => {
     // Hash password
     const passwordHash = await bcrypt.hash(validatedData.password, 12)
 
-    // Create user
-    const user = await fastify.prisma.user.create({
-      data: {
-        username: validatedData.username,
-        email: validatedData.email || null,
-        passwordHash,
-        displayName: validatedData.displayName,
-        isAdmin: validatedData.isAdmin,
-        ...(validatedData.systemRole ? { systemRole: validatedData.systemRole } : {})
-      },
-      select: {
-        id: true,
-        username: true,
-        email: true,
-        displayName: true,
-        isAdmin: true,
-        createdAt: true,
-        updatedAt: true
+    // Create user. The pre-check above narrows the common case, but a duplicate
+    // username/email can still race past it (or collide on email, which is not
+    // pre-checked) — catch the unique violation and return 409 rather than 500.
+    let user
+    try {
+      user = await fastify.prisma.user.create({
+        data: {
+          username: validatedData.username,
+          email: validatedData.email || null,
+          passwordHash,
+          displayName: validatedData.displayName,
+          isAdmin: validatedData.isAdmin,
+          ...(validatedData.systemRole ? { systemRole: validatedData.systemRole } : {})
+        },
+        select: {
+          id: true,
+          username: true,
+          email: true,
+          displayName: true,
+          isAdmin: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      })
+    } catch (error: unknown) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictError(conflictMessageFromP2002(error, {
+          email: 'A user with this email already exists',
+          username: 'Username already exists',
+        }))
       }
-    })
+      throw error
+    }
 
     return reply.code(201).send(user)
   })
@@ -364,7 +398,8 @@ const usersRoute: FastifyPluginAsync = async (fastify) => {
         200: UserSchema,
         404: Type.Object({
           error: Type.String()
-        })
+        }),
+        409: ErrorResponseSchema
       }
     }
   }, async (request, reply) => {
@@ -417,10 +452,23 @@ const usersRoute: FastifyPluginAsync = async (fastify) => {
       if (validatedData.isAdmin !== undefined) {
         invalidateUserAbilities(userId)
       }
+      // An admin password reset must lock out the target's existing sessions
+      // (e.g. compromised account remediation), so revoke them all.
+      if (validatedData.password) {
+        await authService.revokeAllUserSessions(userId)
+      }
       return reply.send(user)
     } catch (error: unknown) {
       if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
         throw new NotFoundError('User', userId)
+      }
+      // A duplicate email/username (or a create/update race) is a client
+      // conflict, not a server fault — surface 409 with the offending field.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictError(conflictMessageFromP2002(error, {
+          email: 'A user with this email already exists',
+          username: 'A user with this username already exists',
+        }))
       }
       throw error
     }
@@ -453,7 +501,8 @@ const usersRoute: FastifyPluginAsync = async (fastify) => {
         }),
         404: Type.Object({
           error: Type.String()
-        })
+        }),
+        409: ErrorResponseSchema
       }
     }
   }, async (request, reply) => {
@@ -462,6 +511,20 @@ const usersRoute: FastifyPluginAsync = async (fastify) => {
     // Prevent self-deletion
     if (request.user?.id === userId) {
       throw new ForbiddenError('Cannot delete yourself')
+    }
+
+    // Project.ownerUserId is onDelete: SetNull, so deleting a user who solely
+    // owns a project (and whose membership cascade-deletes) would strand it with
+    // no owner and no one able to administer it. Refuse and require the admin to
+    // transfer ownership first, preserving the last-owner invariant.
+    const ownedProjects = await fastify.prisma.project.findMany({
+      where: { ownerUserId: userId },
+      select: { name: true },
+    })
+    if (ownedProjects.length > 0) {
+      throw new ConflictError(
+        `Cannot delete a user who solely owns ${ownedProjects.length} project(s). Transfer ownership first: ${ownedProjects.map((p) => p.name).join(', ')}`
+      )
     }
 
     try {

--- a/server/src/services/claim-service.ts
+++ b/server/src/services/claim-service.ts
@@ -817,17 +817,32 @@ export class ClaimService {
       }
     }
 
-    // Create relation; stamp createdBy from the authenticated session.
-    return this.repository.createClaimRelation({
-      sourceClaimId: claimId,
-      targetClaimId,
-      relationTypeId,
-      sourceSpans: (sourceSpans || undefined) as unknown as Prisma.InputJsonValue | undefined,
-      targetSpans: (targetSpans || undefined) as unknown as Prisma.InputJsonValue | undefined,
-      confidence,
-      notes,
-      createdBy: userId,
-    })
+    // Create relation; stamp createdBy from the authenticated session. The
+    // (sourceClaimId, targetClaimId, relationTypeId) triple is unique, so a
+    // retry or double-submit is idempotent: on a duplicate, return the existing
+    // relation rather than minting a second identical row.
+    try {
+      return await this.repository.createClaimRelation({
+        sourceClaimId: claimId,
+        targetClaimId,
+        relationTypeId,
+        sourceSpans: (sourceSpans || undefined) as unknown as Prisma.InputJsonValue | undefined,
+        targetSpans: (targetSpans || undefined) as unknown as Prisma.InputJsonValue | undefined,
+        confidence,
+        notes,
+        createdBy: userId,
+      })
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        const existing = await this.repository.findClaimRelations({
+          sourceClaimId: claimId,
+          targetClaimId,
+          relationTypeId,
+        })
+        if (existing[0]) return existing[0]
+      }
+      throw error
+    }
   }
 
   /**

--- a/server/src/services/claim-service.ts
+++ b/server/src/services/claim-service.ts
@@ -857,32 +857,24 @@ export class ClaimService {
       throw new ForbiddenError('Cannot read this Claim')
     }
 
-    // Filter relations to those whose OTHER endpoint claim is also
-    // readable; otherwise we'd leak existence of claims the caller can't
-    // see via relation payloads.
+    // Filter relations to those whose OTHER endpoint claim is also readable;
+    // otherwise we'd leak the existence and metadata of claims the caller can't
+    // see via relation payloads. The known endpoint (claimId) is already proven
+    // readable above, so an OR over either endpoint would always pass and filter
+    // nothing — each query must require the OPPOSITE endpoint to be accessible.
     const accessibleClaims = accessibleBy(ability, 'read').Claim
 
     const asSource = await this.repository.findClaimRelations({
       AND: [
         { sourceClaimId: claimId },
-        {
-          OR: [
-            { sourceClaim: accessibleClaims },
-            { targetClaim: accessibleClaims },
-          ],
-        },
+        { targetClaim: accessibleClaims },
       ],
     })
 
     const asTarget = await this.repository.findClaimRelations({
       AND: [
         { targetClaimId: claimId },
-        {
-          OR: [
-            { sourceClaim: accessibleClaims },
-            { targetClaim: accessibleClaims },
-          ],
-        },
+        { sourceClaim: accessibleClaims },
       ],
     })
 

--- a/server/src/services/import/entity-importers.ts
+++ b/server/src/services/import/entity-importers.ts
@@ -13,7 +13,7 @@
 
 import { PrismaClient, Prisma } from '@prisma/client'
 import { subject } from '@casl/ability'
-import { NotFoundError, ValidationError } from '../../lib/errors.js'
+import { NotFoundError, ValidationError, ForbiddenError } from '../../lib/errors.js'
 import type { AppAbility } from '../../lib/abilities.js'
 import { ImportLine, ImportOptions, ImportResult, Resolution } from '../import-types.js'
 import { SequenceValidator } from '../import-validator.js'
@@ -174,6 +174,32 @@ export class EntityImporter {
         type: 'validation',
         message: 'Ontology missing required personaId field'
       })
+      return
+    }
+
+    // Authorize against the OWNING persona: importing an ontology overwrites that
+    // persona's types, so the caller must be allowed to update it. Without this,
+    // an import line carrying another user's personaId would clobber their
+    // ontology (IDOR). Checked before the write so the denial propagates cleanly
+    // rather than being swallowed by the generic import-error catch below.
+    const owningPersona = await tx.persona.findUnique({ where: { id: personaId } })
+    if (!owningPersona) {
+      result.errors.push({
+        line: line.lineNumber,
+        type: 'validation',
+        message: `Persona ${personaId} not found for ontology import`
+      })
+      return
+    }
+    if (this.ability && !this.ability.can('update', subject('Persona', owningPersona))) {
+      result.errors.push({
+        line: line.lineNumber,
+        type: 'authorization',
+        message: `Not authorized to import an ontology for persona ${personaId}`
+      })
+      if (options.transaction.atomic) {
+        throw new ForbiddenError(`Not authorized to import an ontology for persona ${personaId}`)
+      }
       return
     }
 

--- a/server/src/services/import/entity-importers.ts
+++ b/server/src/services/import/entity-importers.ts
@@ -17,6 +17,7 @@ import { NotFoundError, ValidationError, ForbiddenError } from '../../lib/errors
 import type { AppAbility } from '../../lib/abilities.js'
 import { ImportLine, ImportOptions, ImportResult, Resolution } from '../import-types.js'
 import { SequenceValidator } from '../import-validator.js'
+import { mergeById } from '../world-state-service.js'
 import { validateLine } from './line-parser.js'
 import { AnnotationData } from './types.js'
 
@@ -274,12 +275,6 @@ export class EntityImporter {
     }
 
     try {
-      // Get current world state
-      const worldState = await tx.worldState.findUnique({ where: { id: worldStateId } })
-      if (!worldState) {
-        throw new NotFoundError('World state', worldStateId)
-      }
-
       // Determine which array to update
       const fieldMap: Record<string, string> = {
         'entity': 'entities',
@@ -292,32 +287,55 @@ export class EntityImporter {
       }
       const fieldName = fieldMap[itemType]
 
-      // Get current array
-      const currentArray = (worldState[fieldName as keyof typeof worldState] as Prisma.JsonValue) || []
-      const items = Array.isArray(currentArray) ? [...currentArray] : []
-
-      // Check if item already exists
-      const existingIndex = items.findIndex(
-        (item) => item && typeof item === 'object' && 'id' in item && item.id === itemId
-      )
-
-      if (existingIndex >= 0) {
-        if (resolution?.action === 'replace') {
-          items[existingIndex] = line.data as Prisma.JsonValue
+      // Merge the imported item into the target array by id under optimistic
+      // concurrency, mirroring the personal world-state write path
+      // (WorldStateRepository.updatePersonalWorldStateOptimistic). The previous
+      // implementation read the row once, mutated one array in memory, and wrote
+      // the whole array back with no updatedAt guard, so a world object added via
+      // the UI during an import (or by a concurrent importer) could be silently
+      // clobbered by this stale snapshot. Here each attempt re-reads the current
+      // row, merges by id against the fresh array, and writes guarded by the
+      // row's updatedAt via updateMany, retrying when the guard misses (count 0).
+      let merged = false
+      for (let attempt = 0; attempt < 5 && !merged; attempt++) {
+        const worldState = await tx.worldState.findUnique({ where: { id: worldStateId } })
+        if (!worldState) {
+          throw new NotFoundError('World state', worldStateId)
         }
-        // Otherwise skip (already exists)
-      } else {
-        items.push(line.data as Prisma.JsonValue)
+
+        const currentArray = (worldState[fieldName as keyof typeof worldState] as Prisma.JsonValue) || []
+        const items = Array.isArray(currentArray) ? currentArray : []
+
+        // Decide what to merge in. mergeById overwrites a matching id with the
+        // incoming item, so only feed it the imported line when the item is new
+        // or the resolution says replace; otherwise feed an empty array so the
+        // existing item is preserved (skip-if-exists) while still merging by id
+        // against the freshly-read current array.
+        const existing = items.some(
+          (item) => item && typeof item === 'object' && 'id' in item && item.id === itemId
+        )
+        const incoming = !existing || resolution?.action === 'replace'
+          ? [line.data]
+          : []
+
+        const nextArray = mergeById(currentArray, incoming)
+
+        const writeResult = await tx.worldState.updateMany({
+          where: { id: worldStateId, updatedAt: worldState.updatedAt },
+          data: {
+            [fieldName]: nextArray,
+            updatedAt: new Date()
+          }
+        })
+
+        if (writeResult.count === 1) {
+          merged = true
+        }
       }
 
-      // Update world state
-      await tx.worldState.update({
-        where: { id: worldStateId },
-        data: {
-          [fieldName]: items as Prisma.InputJsonValue,
-          updatedAt: new Date()
-        }
-      })
+      if (!merged) {
+        throw new Error('World state update conflicted after retries')
+      }
 
       // Update result counts
       switch (itemType) {

--- a/server/src/services/persona-service.ts
+++ b/server/src/services/persona-service.ts
@@ -18,6 +18,7 @@ import {
   countEventInterpretations
 } from '../lib/reference-cleanup.js'
 import { asTypesWithGloss, asEntities, asEvents } from '../lib/prisma-json.js'
+import { mergeById } from '../services/world-state-service.js'
 
 /**
  * Converts a typed array to Prisma.InputJsonValue for storage in JSON columns.
@@ -505,12 +506,17 @@ export class PersonaService {
       throw new ForbiddenError('Cannot update this Persona')
     }
 
-    const updated = await this.repository.updateOntology(id, {
-      entityTypes: input.entities !== undefined ? (input.entities as Prisma.InputJsonValue) : (persona.ontology.entityTypes ?? undefined),
-      roleTypes: input.roles !== undefined ? (input.roles as Prisma.InputJsonValue) : (persona.ontology.roleTypes ?? undefined),
-      eventTypes: input.events !== undefined ? (input.events as Prisma.InputJsonValue) : (persona.ontology.eventTypes ?? undefined),
-      relationTypes: input.relationTypes !== undefined ? (input.relationTypes as Prisma.InputJsonValue) : (persona.ontology.relationTypes ?? undefined)
-    })
+    // Merge each provided array by id (upsert) instead of replacing it, under
+    // optimistic concurrency, so concurrent writers (rapid edits, an AI
+    // augmentation, or a second tab) cannot clobber each other's additions.
+    // Undefined fields are left untouched. Removals go through the explicit
+    // type-deletion routes, never omission.
+    const updated = await this.repository.updateOntologyOptimistic(id, (current) => ({
+      entityTypes: input.entities !== undefined ? mergeById(current.entityTypes, input.entities) : undefined,
+      roleTypes: input.roles !== undefined ? mergeById(current.roleTypes, input.roles) : undefined,
+      eventTypes: input.events !== undefined ? mergeById(current.eventTypes, input.events) : undefined,
+      relationTypes: input.relationTypes !== undefined ? mergeById(current.relationTypes, input.relationTypes) : undefined,
+    }))
 
     return this.mapOntologyResponse(updated)
   }

--- a/server/src/services/project-service.ts
+++ b/server/src/services/project-service.ts
@@ -512,6 +512,17 @@ export class ProjectService {
       throw new NotFoundError('ProjectMembership', targetUserId)
     }
 
+    // Cannot demote the last project_owner — `project_owner` is not an assignable
+    // role (it is set only at creation), so any role change applied to a current
+    // owner is necessarily a demotion that would leave a user-owned project with
+    // no owner. Mirror the last-owner rule enforced on removal.
+    if (targetMembership.role === 'project_owner') {
+      const ownerCount = await this.repository.countMembershipsWithRole(projectId, 'project_owner')
+      if (ownerCount <= 1) {
+        throw new ValidationError('Cannot demote the last project owner')
+      }
+    }
+
     const updated = await this.repository.updateMembershipRole(targetUserId, projectId, role)
 
     // Role change alters the member's effective permissions.

--- a/server/src/services/project-service.ts
+++ b/server/src/services/project-service.ts
@@ -1,4 +1,4 @@
-import { Persona, Prisma } from '@prisma/client'
+import { Persona, Prisma, type WorldState as PrismaWorldState } from '@prisma/client'
 import { subject } from '@casl/ability'
 import type { AppAbility } from '../lib/abilities.js'
 import {
@@ -12,6 +12,7 @@ import {
   ProjectRepository,
   AssignableUser,
 } from '../repositories/ProjectRepository.js'
+import { mergeById } from './world-state-service.js'
 
 /** Convert a value to Prisma JSON without type assertions. */
 function toJson(value: unknown): Prisma.InputJsonValue {
@@ -634,20 +635,11 @@ export class ProjectService {
       throw new ForbiddenError('You must be a project member to access world state')
     }
 
-    let worldState = await this.repository.findWorldState(userId, projectId)
-    if (!worldState) {
-      worldState = await this.repository.createWorldState({
-        userId,
-        projectId,
-        entities: [],
-        events: [],
-        times: [],
-        entityCollections: [],
-        eventCollections: [],
-        timeCollections: [],
-        relations: [],
-      })
-    }
+    // Get-or-create on the compound unique (userId, projectId). Upsert keyed on
+    // the unique avoids the find-then-create race: a concurrent first access
+    // would otherwise have both callers miss the find, both create, and the
+    // second hit the @@unique([userId, projectId]) constraint (P2002 -> 500).
+    const worldState = await this.repository.upsertEmptyWorldState(userId, projectId)
 
     return this.mapWorldState(worldState)
   }
@@ -682,17 +674,24 @@ export class ProjectService {
 
     const existing = await this.repository.findWorldState(userId, projectId)
 
+    // Merge each provided array by id (upsert) instead of replacing it, under
+    // optimistic concurrency. Project world state is multi-user (every project
+    // member shares the (userId, projectId) row), so whole-blob replacement
+    // would let concurrent writers clobber each other's additions; the merge
+    // re-runs against the freshly-read row on each retry.
+    const mergeTransform = (current: PrismaWorldState): Prisma.WorldStateUpdateInput => ({
+      entities: input.entities !== undefined ? mergeById(current.entities, input.entities) : undefined,
+      events: input.events !== undefined ? mergeById(current.events, input.events) : undefined,
+      times: input.times !== undefined ? mergeById(current.times, input.times) : undefined,
+      entityCollections: input.entityCollections !== undefined ? mergeById(current.entityCollections, input.entityCollections) : undefined,
+      eventCollections: input.eventCollections !== undefined ? mergeById(current.eventCollections, input.eventCollections) : undefined,
+      timeCollections: input.timeCollections !== undefined ? mergeById(current.timeCollections, input.timeCollections) : undefined,
+      relations: input.relations !== undefined ? mergeById(current.relations, input.relations) : undefined,
+    })
+
     let worldState
     if (existing) {
-      worldState = await this.repository.updateWorldState(userId, projectId, {
-        entities: input.entities !== undefined ? toJson(input.entities) : undefined,
-        events: input.events !== undefined ? toJson(input.events) : undefined,
-        times: input.times !== undefined ? toJson(input.times) : undefined,
-        entityCollections: input.entityCollections !== undefined ? toJson(input.entityCollections) : undefined,
-        eventCollections: input.eventCollections !== undefined ? toJson(input.eventCollections) : undefined,
-        timeCollections: input.timeCollections !== undefined ? toJson(input.timeCollections) : undefined,
-        relations: input.relations !== undefined ? toJson(input.relations) : undefined,
-      })
+      worldState = await this.repository.updateProjectWorldStateOptimistic(userId, projectId, mergeTransform)
     } else {
       worldState = await this.repository.createWorldState({
         userId,

--- a/server/src/services/project-service.ts
+++ b/server/src/services/project-service.ts
@@ -213,17 +213,27 @@ export class ProjectService {
       throw new ForbiddenError('You do not have permission to create this project')
     }
 
-    const created = await this.repository.createWithOwnerMembership(
-      {
-        name: input.name,
-        description: input.description ?? null,
-        slug: input.slug,
-        ownerUserId: ownerGroupId ? null : userId,
-        ownerGroupId,
-        createdBy: userId,
-      },
-      userId
-    )
+    let created
+    try {
+      created = await this.repository.createWithOwnerMembership(
+        {
+          name: input.name,
+          description: input.description ?? null,
+          slug: input.slug,
+          ownerUserId: ownerGroupId ? null : userId,
+          ownerGroupId,
+          createdBy: userId,
+        },
+        userId
+      )
+    } catch (error) {
+      // The slug pre-check narrows the common case, but a concurrent create with
+      // the same slug can still race past it — surface 409, not 500.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictError(`Project slug "${input.slug}" is already taken`)
+      }
+      throw error
+    }
 
     // Creator is now a project_owner; their abilities have changed.
     invalidateUserAbilities(userId)

--- a/server/src/services/videoSync.ts
+++ b/server/src/services/videoSync.ts
@@ -6,6 +6,7 @@ import {
   selectProjectForVideo,
   ManifestValidationError,
 } from './videoManifest.js'
+import { invalidatePermissionCache } from '../middleware/abilities.js'
 
 /**
  * Logger interface for dependency injection
@@ -252,6 +253,14 @@ async function applyVideoManifest(
       })
       result.videosAssigned += toCreate.length
     }
+  }
+
+  // Manifest reconciliation can change group memberships/roles and project
+  // ownership, all of which feed the in-memory CASL ability cache. Clear it so
+  // a downgrade (e.g. group_admin -> group_member) or ownership change takes
+  // effect immediately rather than lingering until restart/re-login.
+  if (result.membersReconciled > 0 || result.projectsUpserted > 0 || result.groupsUpserted > 0) {
+    invalidatePermissionCache()
   }
 
   logger.info({ ...result }, 'Applied corpus manifest')

--- a/server/src/services/world-state-service.ts
+++ b/server/src/services/world-state-service.ts
@@ -19,6 +19,7 @@ import {
   asWorldCollections,
 } from '../lib/prisma-json.js'
 import { WorldStateRepository } from '../repositories/WorldStateRepository.js'
+import { prisma } from '../lib/prisma.js'
 
 /**
  * Converts a typed array to Prisma.InputJsonValue for storage in JSON columns.
@@ -477,15 +478,30 @@ export class WorldStateService {
   /**
    * Converts every persona ontology's gloss references to a deleted world
    * object into plain text, and returns the total number of references found.
+   *
+   * Both the persona/ontology read and the per-persona ontology writes route
+   * through `tx` when one is supplied, so the gloss cleanup commits or rolls
+   * back atomically with the caller's world-state delete. When `tx` is omitted
+   * the read and writes go through the repository on the default client.
+   *
+   * @param userId - owning user ID
+   * @param objectId - id of the deleted world object
+   * @param refType - the kind of object reference to rewrite
+   * @param objectName - display name to substitute for the reference
+   * @param tx - optional transaction client to run reads/writes inside
+   * @returns the total number of gloss references converted
    */
   private async cleanupGlossReferences(
     userId: string,
     objectId: string,
     refType: 'entity-object' | 'event-object' | 'time-object',
-    objectName: string
+    objectName: string,
+    tx?: Prisma.TransactionClient
   ): Promise<number> {
     let glossReferences = 0
-    const personas = await this.repository.findPersonasWithOntology(userId)
+    const personas = tx
+      ? await tx.persona.findMany({ where: { userId }, include: { ontology: true } })
+      : await this.repository.findPersonasWithOntology(userId)
 
     for (const persona of personas) {
       if (!persona.ontology) continue
@@ -520,15 +536,59 @@ export class WorldStateService {
       }))
 
       // Update ontology
-      await this.repository.updateOntology(persona.id, {
+      const ontologyData = {
         entityTypes: toJson(cleanedEntityTypes),
         roleTypes: toJson(cleanedRoleTypes),
         eventTypes: toJson(cleanedEventTypes),
         relationTypes: toJson(cleanedRelationTypes)
-      })
+      }
+      if (tx) {
+        await tx.ontology.update({ where: { personaId: persona.id }, data: ontologyData })
+      } else {
+        await this.repository.updateOntology(persona.id, ontologyData)
+      }
     }
 
     return glossReferences
+  }
+
+  /**
+   * Applies an optimistic-concurrency update to the personal world state inside
+   * an existing transaction.
+   *
+   * Mirrors WorldStateRepository.updatePersonalWorldStateOptimistic, but reads
+   * and writes through the supplied transaction client so the guarded delete
+   * write and the gloss cleanup commit atomically. Reads the current row,
+   * lets `transform` compute the new column values from it, then writes them
+   * guarded by the row's `updatedAt`; a missed guard (count 0) retries against
+   * the freshly read row so a concurrent addition is not clobbered.
+   *
+   * @param tx - the transaction client to run the read/write inside
+   * @param userId - owning user ID
+   * @param transform - computes the Prisma update input from the current row
+   * @throws when no personal row exists or the write keeps conflicting
+   */
+  private async updatePersonalWorldStateOptimisticTx(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    transform: (current: PrismaWorldState) => Prisma.WorldStateUpdateInput,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const current = await tx.worldState.findFirst({
+        where: { userId, projectId: null },
+      })
+      if (!current) {
+        throw new Error('No personal world state to update')
+      }
+      const result = await tx.worldState.updateMany({
+        where: { id: current.id, updatedAt: current.updatedAt },
+        data: { ...transform(current), updatedAt: new Date() },
+      })
+      if (result.count === 1) {
+        return
+      }
+    }
+    throw new Error('Personal world state update conflicted after retries')
   }
 
   /**
@@ -553,10 +613,11 @@ export class WorldStateService {
     // Count gloss references in all personas' ontologies
     const glossReferences = await this.countGlossReferences(userId, entityId, 'entity-object')
 
-    // Count annotations linking to this entity
-    // Note: Annotations use JSON frames field, need raw query or scan
-    // For simplicity, count annotations that might reference this entity
-    const annotationCount = 0 // Would need to scan frames JSON field
+    // Count object annotations linking to this entity. Object annotations store
+    // the linked world-object id in `label` and its kind in `linkType`.
+    const annotationCount = await prisma.annotation.count({
+      where: { linkType: 'entity', label: entityId }
+    })
 
     // Count relations referencing this entity
     const relations = asWorldRelations(worldState.relations)
@@ -605,43 +666,52 @@ export class WorldStateService {
 
     const entityName = targetEntity.name || entityId
 
-    // Remove entity from list
-    const updatedEntities = entities.filter(e => e.id !== entityId)
-
-    // Remove relations referencing this entity
-    const relations = asWorldRelations(worldState.relations)
-    const relationsRemoved = relations.filter(
-      r => (r.sourceType === 'entity' && r.sourceId === entityId) ||
-           (r.targetType === 'entity' && r.targetId === entityId)
-    ).length
-    const updatedRelations = relations.filter(
-      r => !((r.sourceType === 'entity' && r.sourceId === entityId) ||
-             (r.targetType === 'entity' && r.targetId === entityId))
-    )
-
-    // Remove from collections
-    const entityCollections = asWorldCollections(worldState.entityCollections)
+    // Filter the entity, its relations, and its collection memberships out of
+    // the freshly read row under the updatedAt guard, then convert gloss
+    // references, all inside one transaction so the world-state delete and the
+    // ontology gloss cleanup commit or roll back together. The removed counts
+    // are computed against the fresh row the guarded write actually lands on.
+    let relationsRemoved = 0
     let collectionMemberships = 0
-    const updatedEntityCollections = entityCollections.map(collection => {
-      if (collection.members?.includes(entityId)) {
-        collectionMemberships++
+    const glossReferences = await prisma.$transaction(async (tx) => {
+      relationsRemoved = 0
+      collectionMemberships = 0
+      await this.updatePersonalWorldStateOptimisticTx(tx, userId, (current) => {
+        const currentEntities = asEntities(current.entities)
+        const updatedEntities = currentEntities.filter(e => e.id !== entityId)
+
+        const currentRelations = asWorldRelations(current.relations)
+        relationsRemoved = currentRelations.filter(
+          r => (r.sourceType === 'entity' && r.sourceId === entityId) ||
+               (r.targetType === 'entity' && r.targetId === entityId)
+        ).length
+        const updatedRelations = currentRelations.filter(
+          r => !((r.sourceType === 'entity' && r.sourceId === entityId) ||
+                 (r.targetType === 'entity' && r.targetId === entityId))
+        )
+
+        const currentEntityCollections = asWorldCollections(current.entityCollections)
+        collectionMemberships = 0
+        const updatedEntityCollections = currentEntityCollections.map(collection => {
+          if (collection.members?.includes(entityId)) {
+            collectionMemberships++
+            return {
+              ...collection,
+              members: collection.members.filter(id => id !== entityId)
+            }
+          }
+          return collection
+        })
+
         return {
-          ...collection,
-          members: collection.members.filter(id => id !== entityId)
+          entities: toJson(updatedEntities),
+          relations: toJson(updatedRelations),
+          entityCollections: toJson(updatedEntityCollections)
         }
-      }
-      return collection
-    })
+      })
 
-    // Update world state
-    await this.repository.updateWorldState(worldState.id, {
-      entities: toJson(updatedEntities),
-      relations: toJson(updatedRelations),
-      entityCollections: toJson(updatedEntityCollections)
+      return this.cleanupGlossReferences(userId, entityId, 'entity-object', entityName, tx)
     })
-
-    // Convert objectRefs in glosses
-    const glossReferences = await this.cleanupGlossReferences(userId, entityId, 'entity-object', entityName)
 
     return {
       message: `Entity "${entityName}" deleted successfully`,
@@ -675,6 +745,12 @@ export class WorldStateService {
     // Count gloss references
     const glossReferences = await this.countGlossReferences(userId, eventId, 'event-object')
 
+    // Count object annotations linking to this event. Object annotations store
+    // the linked world-object id in `label` and its kind in `linkType`.
+    const annotationCount = await prisma.annotation.count({
+      where: { linkType: 'event', label: eventId }
+    })
+
     // Count relations
     const relations = asWorldRelations(worldState.relations)
     const relationCount = relations.filter(
@@ -693,7 +769,7 @@ export class WorldStateService {
 
     return {
       glossReferences,
-      annotationCount: 0,
+      annotationCount,
       relationCount,
       collectionMemberships
     }
@@ -722,43 +798,52 @@ export class WorldStateService {
 
     const eventName = targetEvent.name || eventId
 
-    // Remove event
-    const updatedEvents = events.filter(e => e.id !== eventId)
-
-    // Remove relations
-    const relations = asWorldRelations(worldState.relations)
-    const relationsRemoved = relations.filter(
-      r => (r.sourceType === 'event' && r.sourceId === eventId) ||
-           (r.targetType === 'event' && r.targetId === eventId)
-    ).length
-    const updatedRelations = relations.filter(
-      r => !((r.sourceType === 'event' && r.sourceId === eventId) ||
-             (r.targetType === 'event' && r.targetId === eventId))
-    )
-
-    // Remove from collections
-    const eventCollections = asWorldCollections(worldState.eventCollections)
+    // Filter the event, its relations, and its collection memberships out of
+    // the freshly read row under the updatedAt guard, then convert gloss
+    // references, all inside one transaction so the world-state delete and the
+    // ontology gloss cleanup commit or roll back together. The removed counts
+    // are computed against the fresh row the guarded write actually lands on.
+    let relationsRemoved = 0
     let collectionMemberships = 0
-    const updatedEventCollections = eventCollections.map(collection => {
-      if (collection.members?.includes(eventId)) {
-        collectionMemberships++
+    const glossReferences = await prisma.$transaction(async (tx) => {
+      relationsRemoved = 0
+      collectionMemberships = 0
+      await this.updatePersonalWorldStateOptimisticTx(tx, userId, (current) => {
+        const currentEvents = asEvents(current.events)
+        const updatedEvents = currentEvents.filter(e => e.id !== eventId)
+
+        const currentRelations = asWorldRelations(current.relations)
+        relationsRemoved = currentRelations.filter(
+          r => (r.sourceType === 'event' && r.sourceId === eventId) ||
+               (r.targetType === 'event' && r.targetId === eventId)
+        ).length
+        const updatedRelations = currentRelations.filter(
+          r => !((r.sourceType === 'event' && r.sourceId === eventId) ||
+                 (r.targetType === 'event' && r.targetId === eventId))
+        )
+
+        const currentEventCollections = asWorldCollections(current.eventCollections)
+        collectionMemberships = 0
+        const updatedEventCollections = currentEventCollections.map(collection => {
+          if (collection.members?.includes(eventId)) {
+            collectionMemberships++
+            return {
+              ...collection,
+              members: collection.members.filter(id => id !== eventId)
+            }
+          }
+          return collection
+        })
+
         return {
-          ...collection,
-          members: collection.members.filter(id => id !== eventId)
+          events: toJson(updatedEvents),
+          relations: toJson(updatedRelations),
+          eventCollections: toJson(updatedEventCollections)
         }
-      }
-      return collection
-    })
+      })
 
-    // Update world state
-    await this.repository.updateWorldState(worldState.id, {
-      events: toJson(updatedEvents),
-      relations: toJson(updatedRelations),
-      eventCollections: toJson(updatedEventCollections)
+      return this.cleanupGlossReferences(userId, eventId, 'event-object', eventName, tx)
     })
-
-    // Convert objectRefs in glosses
-    const glossReferences = await this.cleanupGlossReferences(userId, eventId, 'event-object', eventName)
 
     return {
       message: `Event "${eventName}" deleted successfully`,
@@ -792,6 +877,12 @@ export class WorldStateService {
     // Count gloss references
     const glossReferences = await this.countGlossReferences(userId, timeId, 'time-object')
 
+    // Count object annotations linking to this time. Object annotations store
+    // the linked world-object id in `label` and its kind in `linkType`.
+    const annotationCount = await prisma.annotation.count({
+      where: { linkType: 'time', label: timeId }
+    })
+
     // Count relations
     const relations = asWorldRelations(worldState.relations)
     const relationCount = relations.filter(
@@ -810,7 +901,7 @@ export class WorldStateService {
 
     return {
       glossReferences,
-      annotationCount: 0,
+      annotationCount,
       relationCount,
       collectionMemberships
     }
@@ -840,43 +931,52 @@ export class WorldStateService {
     // Time objects don't have a name/label, use id for reference cleanup
     const timeName = timeId
 
-    // Remove time
-    const updatedTimes = times.filter(t => t.id !== timeId)
-
-    // Remove relations
-    const relations = asWorldRelations(worldState.relations)
-    const relationsRemoved = relations.filter(
-      r => (r.sourceType === 'time' && r.sourceId === timeId) ||
-           (r.targetType === 'time' && r.targetId === timeId)
-    ).length
-    const updatedRelations = relations.filter(
-      r => !((r.sourceType === 'time' && r.sourceId === timeId) ||
-             (r.targetType === 'time' && r.targetId === timeId))
-    )
-
-    // Remove from collections
-    const timeCollections = asWorldCollections(worldState.timeCollections)
+    // Filter the time, its relations, and its collection memberships out of the
+    // freshly read row under the updatedAt guard, then convert gloss
+    // references, all inside one transaction so the world-state delete and the
+    // ontology gloss cleanup commit or roll back together. The removed counts
+    // are computed against the fresh row the guarded write actually lands on.
+    let relationsRemoved = 0
     let collectionMemberships = 0
-    const updatedTimeCollections = timeCollections.map(collection => {
-      if (collection.members?.includes(timeId)) {
-        collectionMemberships++
+    const glossReferences = await prisma.$transaction(async (tx) => {
+      relationsRemoved = 0
+      collectionMemberships = 0
+      await this.updatePersonalWorldStateOptimisticTx(tx, userId, (current) => {
+        const currentTimes = asTimes(current.times)
+        const updatedTimes = currentTimes.filter(t => t.id !== timeId)
+
+        const currentRelations = asWorldRelations(current.relations)
+        relationsRemoved = currentRelations.filter(
+          r => (r.sourceType === 'time' && r.sourceId === timeId) ||
+               (r.targetType === 'time' && r.targetId === timeId)
+        ).length
+        const updatedRelations = currentRelations.filter(
+          r => !((r.sourceType === 'time' && r.sourceId === timeId) ||
+                 (r.targetType === 'time' && r.targetId === timeId))
+        )
+
+        const currentTimeCollections = asWorldCollections(current.timeCollections)
+        collectionMemberships = 0
+        const updatedTimeCollections = currentTimeCollections.map(collection => {
+          if (collection.members?.includes(timeId)) {
+            collectionMemberships++
+            return {
+              ...collection,
+              members: collection.members.filter(id => id !== timeId)
+            }
+          }
+          return collection
+        })
+
         return {
-          ...collection,
-          members: collection.members.filter(id => id !== timeId)
+          times: toJson(updatedTimes),
+          relations: toJson(updatedRelations),
+          timeCollections: toJson(updatedTimeCollections)
         }
-      }
-      return collection
-    })
+      })
 
-    // Update world state
-    await this.repository.updateWorldState(worldState.id, {
-      times: toJson(updatedTimes),
-      relations: toJson(updatedRelations),
-      timeCollections: toJson(updatedTimeCollections)
+      return this.cleanupGlossReferences(userId, timeId, 'time-object', timeName, tx)
     })
-
-    // Convert objectRefs in glosses
-    const glossReferences = await this.cleanupGlossReferences(userId, timeId, 'time-object', timeName)
 
     return {
       message: `Time "${timeName}" deleted successfully`,

--- a/server/src/services/world-state-service.ts
+++ b/server/src/services/world-state-service.ts
@@ -37,7 +37,7 @@ function toJson(value: unknown): Prisma.InputJsonValue {
  * drops it — the merge re-runs against the freshly-read row via optimistic
  * concurrency. Removals go through the explicit DELETE routes, never omission.
  */
-function mergeById(existing: Prisma.JsonValue | null | undefined, incoming: unknown[]): Prisma.InputJsonValue {
+export function mergeById(existing: Prisma.JsonValue | null | undefined, incoming: unknown[]): Prisma.InputJsonValue {
   const byId = new Map<string, unknown>()
   const order: string[] = []
   const add = (item: unknown) => {
@@ -218,16 +218,29 @@ export class WorldStateService {
           throw new ForbiddenError('Cannot create this WorldState')
         }
       }
-      worldState = await this.repository.createWorldState({
-        userId,
-        entities: [],
-        events: [],
-        times: [],
-        entityCollections: [],
-        eventCollections: [],
-        timeCollections: [],
-        relations: []
-      })
+      try {
+        worldState = await this.repository.createWorldState({
+          userId,
+          entities: [],
+          events: [],
+          times: [],
+          entityCollections: [],
+          eventCollections: [],
+          timeCollections: [],
+          relations: []
+        })
+      } catch (error) {
+        // Concurrent first access can race two creates; the personal-row partial
+        // unique index makes the loser hit P2002. Re-read the winner instead of
+        // 500ing or (pre-index) leaving the user with two personal rows.
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          const winner = await this.repository.findPersonalWorldState(userId)
+          if (!winner) throw error
+          worldState = winner
+        } else {
+          throw error
+        }
+      }
     }
 
     return this.mapResponse(worldState)
@@ -255,23 +268,25 @@ export class WorldStateService {
     // row before mutating it.
     const existing = await this.repository.findPersonalWorldState(userId)
 
+    // Merge each provided array by id (upsert) instead of replacing it, under
+    // optimistic concurrency, so concurrent writers (rapid edits, a Wikidata
+    // import, or a second tab) cannot clobber each other's additions.
+    const mergeTransform = (current: PrismaWorldState) => ({
+      entities: input.entities !== undefined ? mergeById(current.entities, input.entities) : undefined,
+      events: input.events !== undefined ? mergeById(current.events, input.events) : undefined,
+      times: input.times !== undefined ? mergeById(current.times, input.times) : undefined,
+      entityCollections: input.entityCollections !== undefined ? mergeById(current.entityCollections, input.entityCollections) : undefined,
+      eventCollections: input.eventCollections !== undefined ? mergeById(current.eventCollections, input.eventCollections) : undefined,
+      timeCollections: input.timeCollections !== undefined ? mergeById(current.timeCollections, input.timeCollections) : undefined,
+      relations: input.relations !== undefined ? mergeById(current.relations, input.relations) : undefined,
+    })
+
     let worldState
     if (existing) {
       if (this.ability && !this.ability.can('update', subject('WorldState', existing))) {
         throw new ForbiddenError('Cannot update this WorldState')
       }
-      // Merge each provided array by id (upsert) instead of replacing it, under
-      // optimistic concurrency, so concurrent writers (rapid edits, a Wikidata
-      // import, or a second tab) cannot clobber each other's additions.
-      worldState = await this.repository.updatePersonalWorldStateOptimistic(userId, (current) => ({
-        entities: input.entities !== undefined ? mergeById(current.entities, input.entities) : undefined,
-        events: input.events !== undefined ? mergeById(current.events, input.events) : undefined,
-        times: input.times !== undefined ? mergeById(current.times, input.times) : undefined,
-        entityCollections: input.entityCollections !== undefined ? mergeById(current.entityCollections, input.entityCollections) : undefined,
-        eventCollections: input.eventCollections !== undefined ? mergeById(current.eventCollections, input.eventCollections) : undefined,
-        timeCollections: input.timeCollections !== undefined ? mergeById(current.timeCollections, input.timeCollections) : undefined,
-        relations: input.relations !== undefined ? mergeById(current.relations, input.relations) : undefined,
-      }))
+      worldState = await this.repository.updatePersonalWorldStateOptimistic(userId, mergeTransform)
     } else {
       if (this.ability) {
         const candidate = subject('WorldState', { userId, projectId: null })
@@ -279,16 +294,27 @@ export class WorldStateService {
           throw new ForbiddenError('Cannot create this WorldState')
         }
       }
-      worldState = await this.repository.createWorldState({
-        userId,
-        entities: toJson(input.entities || []),
-        events: toJson(input.events || []),
-        times: toJson(input.times || []),
-        entityCollections: toJson(input.entityCollections || []),
-        eventCollections: toJson(input.eventCollections || []),
-        timeCollections: toJson(input.timeCollections || []),
-        relations: toJson(input.relations || [])
-      })
+      try {
+        worldState = await this.repository.createWorldState({
+          userId,
+          entities: toJson(input.entities || []),
+          events: toJson(input.events || []),
+          times: toJson(input.times || []),
+          entityCollections: toJson(input.entityCollections || []),
+          eventCollections: toJson(input.eventCollections || []),
+          timeCollections: toJson(input.timeCollections || []),
+          relations: toJson(input.relations || [])
+        })
+      } catch (error) {
+        // Lost the create race against the personal-row partial unique index —
+        // the row now exists, so merge this input into it rather than 500ing or
+        // (pre-index) silently minting a duplicate personal world state.
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          worldState = await this.repository.updatePersonalWorldStateOptimistic(userId, mergeTransform)
+        } else {
+          throw error
+        }
+      }
     }
 
     return this.mapResponse(worldState)

--- a/server/test/integration/v056-hardening.test.ts
+++ b/server/test/integration/v056-hardening.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { buildApp } from '../../src/app.js'
+import { FastifyInstance } from 'fastify'
+import { PrismaClient } from '@prisma/client'
+import { seedBaselinePermissions, createAdminTestUser, createRegularTestUser } from '../helpers/rbac-test-setup.js'
+
+/**
+ * 0.5.6 correctness/security hardening: duplicate-create conflict handling and
+ * idempotency, session revocation on password change, the last-project-owner
+ * invariant, and the relation/share uniqueness constraints added this release.
+ */
+describe('0.5.6 backend hardening', () => {
+  let app: FastifyInstance
+  let prisma: PrismaClient
+
+  beforeAll(async () => {
+    app = await buildApp()
+    prisma = app.prisma
+  })
+  afterAll(async () => {
+    await app.close()
+  })
+
+  beforeEach(async () => {
+    await prisma.loginAttempt.deleteMany()
+    await prisma.claimRelation.deleteMany()
+    await prisma.claim.deleteMany()
+    await prisma.videoSummary.deleteMany()
+    await prisma.resourceShare.deleteMany()
+    await prisma.projectMembership.deleteMany()
+    await prisma.project.deleteMany()
+    await prisma.ontology.deleteMany()
+    await prisma.persona.deleteMany()
+    await prisma.video.deleteMany()
+    await prisma.session.deleteMany()
+    await prisma.rolePermission.deleteMany()
+    await prisma.user.deleteMany()
+    await seedBaselinePermissions(prisma)
+  })
+
+  // BUG-16: duplicate email/username on admin create returns 409, not 500.
+  it('admin user create returns 409 (not 500) on a duplicate email', async () => {
+    const admin = await createAdminTestUser(prisma, { username: 'admin16', email: 'a16@example.com' })
+    const create = () =>
+      app.inject({
+        method: 'POST',
+        url: '/api/admin/users',
+        cookies: { session_token: admin.sessionToken },
+        payload: { username: 'dupe', email: 'dupe@example.com', password: 'password123', displayName: 'Dupe', isAdmin: false },
+      })
+    expect((await create()).statusCode).toBe(201)
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/admin/users',
+      cookies: { session_token: admin.sessionToken },
+      payload: { username: 'dupe2', email: 'dupe@example.com', password: 'password123', displayName: 'Dupe2', isAdmin: false },
+    })
+    expect(second.statusCode).toBe(409)
+  })
+
+  // BUG-02: changing the password revokes the caller's existing sessions.
+  it('a password change invalidates the old session token', async () => {
+    const user = await createRegularTestUser(prisma, { username: 'pw02', email: 'pw02@example.com' })
+    const oldToken = user.sessionToken
+
+    // The old token works before the change.
+    expect((await app.inject({ method: 'GET', url: '/api/auth/abilities', cookies: { session_token: oldToken } })).statusCode).toBe(200)
+
+    const change = await app.inject({
+      method: 'PUT',
+      url: '/api/user/profile',
+      cookies: { session_token: oldToken },
+      payload: { password: 'brand-new-password' },
+    })
+    expect(change.statusCode).toBe(200)
+
+    // The old token is revoked; a fresh session cookie was issued in the response.
+    const after = await app.inject({ method: 'GET', url: '/api/auth/abilities', cookies: { session_token: oldToken } })
+    expect(after.statusCode).toBe(401)
+  })
+
+  // BUG-12: re-sharing the same resource to the same target is idempotent.
+  it('sharing the same persona to the same user twice creates one share', async () => {
+    const owner = await createRegularTestUser(prisma, { username: 'owner12', email: 'o12@example.com' })
+    const target = await createRegularTestUser(prisma, { username: 'target12', email: 't12@example.com' })
+    const persona = await prisma.persona.create({
+      data: { userId: owner.id, name: 'P', role: 'Analyst', informationNeed: 'n' },
+    })
+
+    const share = () =>
+      app.inject({
+        method: 'POST',
+        url: '/api/sharing',
+        cookies: { session_token: owner.sessionToken },
+        payload: { resourceType: 'persona', resourceId: persona.id, sharedWithUserId: target.id, permissionLevel: 'read_only' },
+      })
+
+    expect((await share()).statusCode).toBe(201)
+    expect((await share()).statusCode).toBe(201)
+
+    const rows = await prisma.resourceShare.findMany({ where: { resourceId: persona.id } })
+    expect(rows).toHaveLength(1)
+  })
+
+  // BUG-26: the last project_owner cannot be demoted, leaving the project ownerless.
+  it('refuses to demote the last project owner', async () => {
+    const owner = await createRegularTestUser(prisma, { username: 'owner26', email: 'o26@example.com' })
+    const manager = await createRegularTestUser(prisma, { username: 'mgr26', email: 'm26@example.com' })
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/projects',
+      cookies: { session_token: owner.sessionToken },
+      payload: { name: 'Proj 26', slug: 'proj-26' },
+    })
+    expect(created.statusCode).toBe(201)
+    const projectId = created.json().id
+
+    // Add the manager so they have manage_members.
+    await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/members`,
+      cookies: { session_token: owner.sessionToken },
+      payload: { userId: manager.id, role: 'project_manager' },
+    })
+
+    // The manager tries to demote the sole owner -> blocked.
+    const demote = await app.inject({
+      method: 'PUT',
+      url: `/api/projects/${projectId}/members/${owner.id}`,
+      cookies: { session_token: manager.sessionToken },
+      payload: { role: 'viewer' },
+    })
+    expect(demote.statusCode).toBe(400)
+    const stillOwner = await prisma.projectMembership.findFirst({ where: { projectId, userId: owner.id } })
+    expect(stillOwner?.role).toBe('project_owner')
+  })
+})


### PR DESCRIPTION
## Description

First of three audit-driven hardening releases (the **backend** slice, v0.5.6). Fixes a batch of authorization, data-integrity, idempotency, and concurrency defects surfaced by the v0.5.5 swarm audit. Nothing is breaking; the API additively gains `409 Conflict` responses on duplicate creates and the resource-fork now produces correctly-scoped resources. Frontend and model-service fixes follow in 0.5.7 and 0.5.8.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/infrastructure changes

## Related Issues

N/A — internal audit findings.

## Changes Made

**Authorization & access control:** gate Bull Board `/admin/queues` behind admin auth; revoke sessions on password change (self + admin); enforce persona ownership on ontology import (IDOR); fix the no-op claim-relation privacy filter; invalidate the ability cache on manifest-sync membership/ownership changes; enforce the last-project-owner invariant on change-role and admin user-delete; make `trustProxy` configurable (default 1 hop); constrain the demo-seed `tourId`.

**Idempotency & conflict handling:** duplicate resource shares and claim relations are idempotent (reuse the existing row); duplicate user email/username and group/project slugs return `409` not `500`; new uniqueness constraints (a `ClaimRelation` triple + partial unique indexes on `ResourceShare` and personal `WorldState`), with a migration that dedupes pre-existing duplicates first; personal world-state get-or-create is race-safe.

**Concurrency (lost updates):** persona-ontology, project world-state, and import world-state writes now merge each array by id under optimistic concurrency (same pattern as personal world-state).

**Deletion integrity:** world-object deletes run the world-state write + gloss cleanup in one transaction under the optimistic guard; deletion previews report real annotation counts.

**Deep-fork:** shared summaries/claims/annotations deep-fork into the forker's scope (fork the persona, re-point the summary/claim, rebuild `claimsJson`, preserve annotation `linkType`).

## Testing

### Test Environment

- OS: macOS (darwin) + CI (linux)
- Browser (if applicable): Chromium (Playwright)
- Node version: 22
- Python version (if applicable): N/A

### Test Cases

- [x] Unit tests added/updated
- [x] E2E tests added/updated (if applicable)
- [x] Manual testing completed
- [x] All existing tests pass

### How to Test

1. Server: `cd server && npx vitest run` against a Postgres test DB — **1290 existing + 4 new** hardening tests pass (duplicate-create 409, password-change session revocation, share idempotency, last-owner demotion guard).
2. Migration: `prisma migrate deploy` applies the dedupe + uniqueness migration cleanly; `migrate status` is up to date.
3. E2E: full Playwright smoke/functional/regression/accessibility on the e2e stack — **459 passed, 0 failures** (10 load-flaky specs pass on retry).

## Screenshots/Videos

N/A

## Documentation

- [ ] Code comments updated
- [x] API documentation updated
- [ ] User guide updated
- [ ] README updated
- [x] CHANGELOG updated (for user-visible changes)
- [ ] No documentation needed

## Performance Impact

- [x] No significant performance impact
- [ ] Performance improved (describe below)
- [ ] Performance may be affected (describe below and justify)

Details: The optimistic-concurrency writes add a bounded retry that only re-runs on a concurrent-write collision.

## Breaking Changes

**Breaking changes:**
- None. All API changes are additive (new `409` responses; the fork now succeeds and produces correctly-scoped resources).

**Migration guide:**
- N/A. The new migration dedupes any pre-existing duplicate claim-relations / resource-shares / personal world-states before adding the uniqueness constraints.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The `ResourceShare` and personal-`WorldState` partial unique indexes are created as raw SQL in the migration (Prisma cannot express `WHERE` partial indexes declaratively); the project applies migrations with `prisma migrate deploy`, which preserves them. E2E was run on an isolated-port stack; one prerequisite was installing the Playwright Chromium browser locally.

## Reviewer Guidance

The largest surfaces are the world-state deletion transactions (`world-state-service.ts`) and the deep-fork (`sharing.ts`). Note that merge-by-id intentionally makes removal-by-omission a no-op everywhere it is applied — removals go through the dedicated DELETE/graceful-delete routes.
